### PR TITLE
Mac Lion Support

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -22,7 +22,7 @@ with_ruby = File.join(Config::CONFIG["bindir"], Config::CONFIG["RUBY_INSTALL_NAM
 other_opts = ""
 env = ""
 
-if RUBY_PLATFORM =~ /darwin10/
+if RUBY_PLATFORM =~ /darwin10/ || RUBY_PLATFORM =~ /darwin11/
   arch = Config::CONFIG["arch"].split("-")[0]
 
   if arch == "universal"


### PR DESCRIPTION
I was getting the following error when trying to do a "gem install" 

```
g++ -DHAVE_CONFIG_H -I.  -I/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/universal-darwin11.0  -arch i386 -arch x86_64 -g -Os -pipe -fno-common -DENABLE_DTRACE  -fno-common  -pipe -fno-common    -fno-common -I/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/universal-darwin11.0 -MT Class.o -MD -MP -MF .deps/Class.Tpo -c -o Class.o Class.cpp
llvm-g++-4.2: -E, -S, -save-temps and -M options are not allowed with multiple -arch flags
```

I added Darwin 11.0 to extconf.rb, treating it the exact same as Darwin 10.0. Works on mine, could not find any test cases to add / modify.
