### PR TITLE
Fix typo in static Ruby build warning

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -25,7 +25,7 @@ Unfortunately Rice does not work against a Ruby without any shared libraries.
 You'll need to rebuild Ruby with --enable-shared to use this library.
 
 If you're on rvm:   rvm reinstall [version] -- --enable-shared
-If you're on rbenv: CONFIGURE_OPTS="--enable-shard" rbenv install [version]
+If you're on rbenv: CONFIGURE_OPTS="--enable-shared" rbenv install [version]
 If this is a host environment like Heroku you'll need to contact their support.
 EOC
 end


### PR DESCRIPTION
`--enable-shared` is typo'd as `--enable-shard` on the rbenv command example.

I copy-pasted that example and added my ruby version. rbenv didn't complain, but the installation still failed. I hope this patch will help other people not bump into the same tiny glitch.

Thank you for that warning message! It's a huge improvement over the previous build errors!
