### PR TITLE
run bootstrap automatically

### DIFF
--- a/extconf.rb
+++ b/extconf.rb
@@ -47,4 +47,5 @@ elsif RUBY_PLATFORM =~ /darwin9/
   env = "ARCHFLAGS='-arch #{arch}' CPPFLAGS='-arch #{arch}'"
 end
 
+system "sh bootstrap"
 system "#{env} sh configure --with-ruby=#{with_ruby} --prefix=#{prefix_dir} #{other_opts}"


### PR DESCRIPTION
if a system has an older version of autoconf installed, building the
gem's native extensions fail.  run bootstrap before configure so that
autoreconf is run and the configuration succeeds.
