### PR TITLE
Deploy docs to the new organization repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,14 +51,14 @@ Rice 4.0 is a significant change from 3.0 and has multiple backwards-incompatibl
 changes. Rice 4.0 no longer requires pre-compilation and is now a header-only library,
 delivered as a combined header file.
 
-For migrating from 3 to 4, see [the migration guide](https://jasonroelofs.com/rice/4.x/migration.html).
+For migrating from 3 to 4, see [the migration guide](https://ruby-rice.github.io/4.x/migration.html).
 
 There are a ton of changes, but some of the most important ones:
 
 * Header only! `#include <rice/rice.hpp>`
 * Requires C++17 or later
 * Brand new, expanded documentation
-* [Built-in STL support](https://jasonroelofs.com/rice/4.x/stl/stl.html)
+* [Built-in STL support](https://ruby-rice.github.io/4.x/stl/stl.html)
 * And so much more. See the documentation for more details.
 
 ## 3.0

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ This documentation and the `master` branch are for Rice 4.x and later, which is 
 header-only version of this library. Use the `3.x` branch for the docs and code for that
 line of releases.
 
-The docs for the 3.x line of Rice is at https://jasonroelofs.com/rice/3.x.
+The docs for the 3.x line of Rice is at https://ruby-rice.github.io/3.x.
 
 # Project Details
 
-The source is hosted on GitHub: http://github.com/jasonroelofs/rice
+The source is hosted on GitHub: http://github.com/ruby-rice/rice
 
-Bug tracking: http://github.com/jasonroelofs/rice/issues
+Bug tracking: http://github.com/ruby-rice/rice/issues
 
-API documentation: http://jasonroelofs.github.io/rice
+API documentation: http://ruby-rice.github.io/
 
 # Installation
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Rice'
-copyright = '2023, Paul Brannon, Jason Roelofs, Charlie Savage'
+copyright = '2024, Paul Brannon, Jason Roelofs, Charlie Savage'
 author = 'Paul Brannon, Jason Roelofs, Charlie Savage'
 
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -21,16 +21,16 @@ This documentation and the ``master`` branch are for Rice 4.x and later, which i
 
 To upgrade a library from Rice 3 to 4, see :ref:`Migrating`.
 
-The documentation for the 3.x line of Rice is viewable at https://jasonroelofs.com/rice/3.x.
+The documentation for the 3.x line of Rice is viewable at https://ruby-rice.github.io/3.x.
 
 Project Details
 ---------------
 
-The source is hosted on GitHub: http://github.com/jasonroelofs/rice
+The source is hosted on GitHub: http://github.com/ruby-rice/rice
 
-Bug tracking: http://github.com/jasonroelofs/rice/issues
+Bug tracking: http://github.com/ruby-rice/rice/issues
 
-API documentation: http://jasonroelofs.com/rice
+API documentation: http://ruby-rice.github.io/4.x
 
 Installation
 ------------

--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -25,7 +25,7 @@ Next create an extconf.rb file:
 Note that we use ``mkmf-rice`` instead of ``mkmf``. This will ensure that the extension will be linked with standard C++ library and allows access to the Rice header files.
 
 .. note::
-  For advanced users - instead of using mkmf-rice you can use your own build system such as CMake. In this case you may prefer to download the Rice header file, `rice.hpp <https://github.com/jasonroelofs/rice/blob/master/include/rice/rice.hpp>`_, from github and directly include it in your source tree.
+  For advanced users - instead of using mkmf-rice you can use your own build system such as CMake. In this case you may prefer to download the Rice header file, `rice.hpp <https://github.com/ruby-rice/rice/blob/master/include/rice/rice.hpp>`_, from github and directly include it in your source tree.
   
 Next we create our extension and save it to ``test.cpp``:
 

--- a/rice.gemspec
+++ b/rice.gemspec
@@ -6,7 +6,7 @@ $spec = Gem::Specification.new do |s|
   s.version = Rice::VERSION
   s.license = "MIT"
   s.summary = 'Ruby Interface for C++ Extensions'
-  s.homepage = 'https://github.com/jasonroelofs/rice'
+  s.homepage = 'https://github.com/ruby-rice/rice'
   s.authors = ['Paul Brannan', 'Jason Roelofs', 'Charlie Savage']
   s.email = ['curlypaul924@gmail.com', 'jasonroelofs@gmail.com', 'cfis@savagexi.com']
 
@@ -17,10 +17,10 @@ Ruby extensions with C++ easier.
   END
 
   s.metadata = {
-    "bug_tracker_uri"   => "https://github.com/jasonroelofs/rice/issues",
-    "changelog_uri"     => "https://github.com/jasonroelofs/rice/blob/master/CHANGELOG.md",
-    "documentation_uri" => "https://jasonroelofs.com/rice",
-    "source_code_uri"   => "https://github.com/jasonroelofs/rice",
+    "bug_tracker_uri"   => "https://github.com/ruby-rice/rice/issues",
+    "changelog_uri"     => "https://github.com/ruby-rice/rice/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://ruby-rice.github.io",
+    "source_code_uri"   => "https://github.com/ruby-rice/rice",
   }
 
   s.test_files = Dir['test/ruby/*.rb']


### PR DESCRIPTION
I'm getting things set up for moving to our own organization. The website now exists over there and updating the repo to no longer link to `jasonroelofs.com`.

https://github.com/ruby-rice

https://ruby-rice.github.io

I need to get this repo flagged as the canonical one from cout/rice before I move it to the new org.