### PR TITLE
Improve exception handling for bad any cast

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -1152,7 +1152,12 @@ namespace Rice::detail
     }
 
     std::any data = iter->second;
-    return std::any_cast<Return_T>(data);
+    auto* ptr = std::any_cast<Return_T>(&data);
+    if (!ptr)
+    {
+      rb_raise(rb_eRuntimeError, "Bad any cast for %s %s", rb_class2name(klass), rb_id2name(method_id));
+    }
+    return *ptr;
   }
 }
 

--- a/rice/detail/NativeRegistry.ipp
+++ b/rice/detail/NativeRegistry.ipp
@@ -52,6 +52,11 @@ namespace Rice::detail
     }
 
     std::any data = iter->second;
-    return std::any_cast<Return_T>(data);
+    auto* ptr = std::any_cast<Return_T>(&data);
+    if (!ptr)
+    {
+      rb_raise(rb_eRuntimeError, "Bad any cast for %s %s", rb_class2name(klass), rb_id2name(method_id));
+    }
+    return *ptr;
   }
 }


### PR DESCRIPTION
Hi, currently bad any cast causes the Ruby program to crash, which isn't ideal for end users.

```text
libc++abi: terminating due to uncaught exception of type std::bad_any_cast: bad any cast
SignalException: SIGABRT (SignalException)
```

This PR changes it to raise an exception (with some context) instead.

```text
RuntimeError: Bad any cast for DataSketches::HllUnion update
```

---

I'm seeing this error across a number of projects, but still trying to figure out the cause. From the error, it seems like `NativeRegistry` may be getting corrupted, or the function is never properly registered to begin with (as it either happens never or every time for the lifetime of the program).