### PR TITLE
Fix `bad any cast` errors caused by hash collisions

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -1075,6 +1075,7 @@ namespace Rice::detail
 
 #include <unordered_map>
 #include <any>
+#include <tuple>
 
 
 namespace Rice::detail
@@ -1093,8 +1094,8 @@ namespace Rice::detail
     Return_T lookup(VALUE klass, ID method_id);
 
   private:
-    std::pair<VALUE, ID> key(VALUE klass, ID method_id);
-    std::map<std::pair<VALUE, ID>, std::any> natives_ = {};
+    size_t key(VALUE klass, ID method_id);
+    std::unordered_multimap<size_t, std::tuple<VALUE, ID, std::any>> natives_ = {};
   };
 }
 
@@ -1112,20 +1113,32 @@ namespace Rice::detail
 {
   // Effective Java (2nd edition)
   // https://stackoverflow.com/a/2634715
-  inline std::pair<VALUE, ID> NativeRegistry::key(VALUE klass, ID id)
+  inline size_t NativeRegistry::key(VALUE klass, ID id)
+  {
+    uint32_t prime = 53;
+    return (prime + klass) * prime + id;
+  }
+
+  inline void NativeRegistry::add(VALUE klass, ID method_id, std::any callable)
   {
     if (rb_type(klass) == T_ICLASS)
     {
       klass = detail::protect(rb_class_of, klass);
     }
 
-    return std::make_pair(klass, id);
-  }
+    auto range = this->natives_.equal_range(key(klass, method_id));
+    for (auto it = range.first; it != range.second; ++it)
+    {
+      const auto [k, m, d] = it->second;
 
-  inline void NativeRegistry::add(VALUE klass, ID method_id, std::any callable)
-  {
-    // Now store data about it
-    this->natives_[key(klass, method_id)] = callable;
+      if (k == klass && m == method_id)
+      {
+        std::get<2>(it->second) = callable;
+        return;
+      }
+    }
+
+    this->natives_.emplace(std::make_pair(key(klass, method_id), std::make_tuple(klass, method_id, callable)));
   }
 
   template <typename Return_T>
@@ -1144,14 +1157,23 @@ namespace Rice::detail
   template <typename Return_T>
   inline Return_T NativeRegistry::lookup(VALUE klass, ID method_id)
   {
-    auto iter = this->natives_.find(key(klass, method_id));
-    if (iter == this->natives_.end())
+    if (rb_type(klass) == T_ICLASS)
     {
-      rb_raise(rb_eRuntimeError, "Could not find data for klass and method id");
+      klass = detail::protect(rb_class_of, klass);
     }
 
-    std::any data = iter->second;
-    return std::any_cast<Return_T>(data);
+    auto range = this->natives_.equal_range(key(klass, method_id));
+    for (auto it = range.first; it != range.second; ++it)
+    {
+      const auto [k, m, d] = it->second;
+
+      if (k == klass && m == method_id)
+      {
+        return std::any_cast<Return_T>(d);
+      }
+    }
+
+    rb_raise(rb_eRuntimeError, "Could not find data for klass and method id");
   }
 }
 

--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -1093,10 +1093,10 @@ namespace Rice::detail
     Return_T lookup(VALUE klass, ID method_id);
 
   private:
-    size_t key(VALUE klass, ID method_id);
-    std::unordered_map<size_t, std::any> natives_ = {};
+    std::pair<VALUE, ID> key(VALUE klass, ID method_id);
+    std::map<std::pair<VALUE, ID>, std::any> natives_ = {};
   };
-} 
+}
 
 // ---------   NativeRegistry.ipp   ---------
 
@@ -1112,15 +1112,14 @@ namespace Rice::detail
 {
   // Effective Java (2nd edition)
   // https://stackoverflow.com/a/2634715
-  inline size_t NativeRegistry::key(VALUE klass, ID id)
+  inline std::pair<VALUE, ID> NativeRegistry::key(VALUE klass, ID id)
   {
     if (rb_type(klass) == T_ICLASS)
     {
       klass = detail::protect(rb_class_of, klass);
     }
 
-    uint32_t prime = 53;
-    return (prime + klass) * prime + id;
+    return std::make_pair(klass, id);
   }
 
   inline void NativeRegistry::add(VALUE klass, ID method_id, std::any callable)

--- a/rice/detail/NativeRegistry.hpp
+++ b/rice/detail/NativeRegistry.hpp
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 #include <any>
+#include <tuple>
 
 #include "ruby.hpp"
 
@@ -22,8 +23,8 @@ namespace Rice::detail
     Return_T lookup(VALUE klass, ID method_id);
 
   private:
-    std::pair<VALUE, ID> key(VALUE klass, ID method_id);
-    std::map<std::pair<VALUE, ID>, std::any> natives_ = {};
+    size_t key(VALUE klass, ID method_id);
+    std::unordered_multimap<size_t, std::tuple<VALUE, ID, std::any>> natives_ = {};
   };
 }
 #include "NativeRegistry.ipp"

--- a/rice/detail/NativeRegistry.hpp
+++ b/rice/detail/NativeRegistry.hpp
@@ -22,10 +22,10 @@ namespace Rice::detail
     Return_T lookup(VALUE klass, ID method_id);
 
   private:
-    size_t key(VALUE klass, ID method_id);
-    std::unordered_map<size_t, std::any> natives_ = {};
+    std::pair<VALUE, ID> key(VALUE klass, ID method_id);
+    std::map<std::pair<VALUE, ID>, std::any> natives_ = {};
   };
-} 
+}
 #include "NativeRegistry.ipp"
 
 #endif // Rice__detail__NativeRegistry__hpp

--- a/rice/detail/NativeRegistry.ipp
+++ b/rice/detail/NativeRegistry.ipp
@@ -12,15 +12,14 @@ namespace Rice::detail
 {
   // Effective Java (2nd edition)
   // https://stackoverflow.com/a/2634715
-  inline size_t NativeRegistry::key(VALUE klass, ID id)
+  inline std::pair<VALUE, ID> NativeRegistry::key(VALUE klass, ID id)
   {
     if (rb_type(klass) == T_ICLASS)
     {
       klass = detail::protect(rb_class_of, klass);
     }
 
-    uint32_t prime = 53;
-    return (prime + klass) * prime + id;
+    return std::make_pair(klass, id);
   }
 
   inline void NativeRegistry::add(VALUE klass, ID method_id, std::any callable)

--- a/test/test_Native_Registry.cpp
+++ b/test/test_Native_Registry.cpp
@@ -1,0 +1,50 @@
+#include "unittest.hpp"
+#include "embed_ruby.hpp"
+
+#include <rice/rice.hpp>
+#include <rice/stl.hpp>
+
+using namespace Rice;
+
+TESTSUITE(NativeRegistry);
+
+SETUP(NativeRegistry)
+{
+  embed_ruby();
+}
+
+TESTCASE(collisions)
+{
+  std::array<Class, 100> classes;
+  int scale = 1000;
+
+  for (int i = 0; i < std::size(classes); i++)
+  {
+    Class cls(anonymous_class());
+
+    for (int j = 0; j < scale; j++)
+    {
+      cls.define_function("int" + std::to_string(j), []() { return 1; });
+      cls.define_function("long" + std::to_string(j), []() { return 1L; });
+      cls.define_function("double" + std::to_string(j), []() { return 1.0; });
+      cls.define_function("float" + std::to_string(j), []() { return 1.0f; });
+      cls.define_function("bool" + std::to_string(j), []() { return true; });
+    }
+
+    classes[i] = cls;
+  }
+
+  for (auto& cls : classes)
+  {
+    auto obj = cls.call("new");
+
+    for (int j = 0; j < scale; j++)
+    {
+      obj.call("int" + std::to_string(j));
+      obj.call("long" + std::to_string(j));
+      obj.call("double" + std::to_string(j));
+      obj.call("float" + std::to_string(j));
+      obj.call("bool" + std::to_string(j));
+    }
+  }
+}


### PR DESCRIPTION
This updates the `NativeRegistry` to handle hash collisions, which should fix random `bad any cast` errors.

Ref: https://github.com/ruby-rice/rice/pull/207#issuecomment-2395874364

<strike>Edit: Not very happy with the latest approach. There should be a much more performant way to do this.</strike>

Edit 2: I'm not sure putting `VALUE`s on the heap is a good idea, so it may be better to go back to the previous approach: 819515ba4fecde9146d6f96035f109b89f9fef22. Also, choosing a larger prime in the `key` function reduces collisions significantly, but I think they need to be handled anyways.