### PR TITLE
Fix compilation on Ubuntu 20.04

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ['3.0', '3.1', '3.2', '3.3']
+        include:
+          - os: ubuntu-20.04
+            ruby: '3.1'
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/rice/detail/NativeRegistry.hpp
+++ b/rice/detail/NativeRegistry.hpp
@@ -3,7 +3,6 @@
 
 #include <unordered_map>
 #include <any>
-#include <tuple>
 
 #include "ruby.hpp"
 
@@ -23,8 +22,7 @@ namespace Rice::detail
     Return_T lookup(VALUE klass, ID method_id);
 
   private:
-    size_t key(VALUE klass, ID method_id);
-    std::unordered_multimap<size_t, std::tuple<VALUE, ID, std::any>> natives_ = {};
+    std::unordered_multimap<ID, std::pair<VALUE, std::any>> natives_ = {};
   };
 }
 #include "NativeRegistry.ipp"

--- a/rice/detail/NativeRegistry.ipp
+++ b/rice/detail/NativeRegistry.ipp
@@ -10,14 +10,6 @@
 
 namespace Rice::detail
 {
-  // Effective Java (2nd edition)
-  // https://stackoverflow.com/a/2634715
-  inline size_t NativeRegistry::key(VALUE klass, ID id)
-  {
-    uint32_t prime = 53;
-    return (prime + klass) * prime + id;
-  }
-
   inline void NativeRegistry::add(VALUE klass, ID method_id, std::any callable)
   {
     if (rb_type(klass) == T_ICLASS)
@@ -25,19 +17,19 @@ namespace Rice::detail
       klass = detail::protect(rb_class_of, klass);
     }
 
-    auto range = this->natives_.equal_range(key(klass, method_id));
+    auto range = this->natives_.equal_range(method_id);
     for (auto it = range.first; it != range.second; ++it)
     {
-      const auto [k, m, d] = it->second;
+      const auto [k, d] = it->second;
 
-      if (k == klass && m == method_id)
+      if (k == klass)
       {
-        std::get<2>(it->second) = callable;
+        std::get<1>(it->second) = callable;
         return;
       }
     }
 
-    this->natives_.emplace(std::make_pair(key(klass, method_id), std::make_tuple(klass, method_id, callable)));
+    this->natives_.emplace(std::make_pair(method_id, std::make_pair(klass, callable)));
   }
 
   template <typename Return_T>
@@ -61,12 +53,12 @@ namespace Rice::detail
       klass = detail::protect(rb_class_of, klass);
     }
 
-    auto range = this->natives_.equal_range(key(klass, method_id));
+    auto range = this->natives_.equal_range(method_id);
     for (auto it = range.first; it != range.second; ++it)
     {
-      const auto [k, m, d] = it->second;
+      const auto [k, d] = it->second;
 
-      if (k == klass && m == method_id)
+      if (k == klass)
       {
         auto* ptr = std::any_cast<Return_T>(&d);
         if (!ptr)


### PR DESCRIPTION
Compilation currently fails with GCC 9.

```text
/home/runner/work/torch.rb/torch.rb/vendor/bundle/ruby/3.1.0/gems/rice-4.3.2/include/rice/rice.hpp:1141:109:   required from here
/usr/include/c++/9/type_traits:131:12: error: incomplete type ‘std::is_copy_constructible<std::_Tuple_impl<2, std::any> >’ used in nested name specifier
```

Ref: https://stackoverflow.com/questions/65163455/stdany-containing-stdtuplestdany-fails-to-compile