### PR TITLE
Simplify mkmf-rice, part 2

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,6 +16,8 @@ jobs:
         include:
           - os: ubuntu-20.04
             ruby: '3.1'
+          - os: macos-13
+            ruby: '3.0'
         exclude:
           # There's something wrong with this setup in GHA such that
           # it gets weird linking errors, however I'm unable to reproduce

--- a/lib/mkmf-rice.rb
+++ b/lib/mkmf-rice.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 
-IS_MSWIN = RbConfig::CONFIG['host_os'].match?(/mswin/)
-IS_MINGW = RbConfig::CONFIG['host_os'].match?(/mingw/)
+IS_MSWIN = /mswin/ =~ RUBY_PLATFORM
+IS_MINGW = /mingw/ =~ RUBY_PLATFORM
 IS_DARWIN = RbConfig::CONFIG['host_os'].match?(/darwin/)
 
 # The cpp_command is not overwritten in the experimental mkmf C++ support.
@@ -38,10 +38,6 @@ unless find_header('rice/rice.hpp', path)
   raise("Could not find rice/rice.hpp header")
 end
 
-if IS_DARWIN
-  have_library('c++')
-elsif !IS_MSWIN
-  if !have_library('stdc++fs')
-    have_library('stdc++')
-  end
+if !IS_DARWIN && !IS_MSWIN && !have_library('stdc++fs')
+  have_library('stdc++')
 end


### PR DESCRIPTION
A few more changes:

1. Updates `IS_MSWIN` and `IS_MINGW` detection to match Ruby as suggested in #211 
2. Fixes `ld: warning: ignoring duplicate libraries: '-lc++'` on Mac (and adds `macos-13` to CI for this and future changes)
3. <strike>Removes the `cpp_command` override (the code [hasn't been updated](https://github.com/ruby/ruby/blame/master/lib/mkmf.rb#L576-L583) since the bug was filed, but will see if it compiles on CI)</strike>