### PR TITLE
RValue parameters

### DIFF
--- a/rice/Data_Object_defn.hpp
+++ b/rice/Data_Object_defn.hpp
@@ -45,6 +45,7 @@ namespace Rice
     static_assert(!std::is_reference_v<T>);
     static_assert(!std::is_const_v<T>);
     static_assert(!std::is_volatile_v<T>);
+    static_assert(!std::is_void_v<T>);
 
   public:
     static T* from_ruby(VALUE value);

--- a/rice/detail/NativeFunction.hpp
+++ b/rice/detail/NativeFunction.hpp
@@ -101,8 +101,8 @@ namespace Rice::detail
     void checkKeepAlive(VALUE self, VALUE returnValue, std::vector<VALUE>& rubyValues);
 
     // Call the underlying C++ function
-    VALUE invokeNativeFunction(const Arg_Ts& nativeArgs);
-    VALUE invokeNativeMethod(VALUE self, const Arg_Ts& nativeArgs);
+    VALUE invokeNativeFunction(Arg_Ts&& nativeArgs);
+    VALUE invokeNativeMethod(VALUE self, Arg_Ts&& nativeArgs);
 
   private:
     VALUE klass_;

--- a/test/test_Constructor.cpp
+++ b/test/test_Constructor.cpp
@@ -7,6 +7,11 @@ using namespace Rice;
 
 TESTSUITE(Constructor);
 
+SETUP(Construtor)
+{
+  embed_ruby();
+}
+
 namespace
 {
   class Default_Constructible
@@ -16,11 +21,6 @@ namespace
     {
     }
   };
-}
-
-SETUP(Array)
-{
-  embed_ruby();
 }
 
 TESTCASE(default_constructor)
@@ -124,4 +124,53 @@ TESTCASE(constructor_supports_single_default_argument)
 
   klass.call("new", 6);
   ASSERT_EQUAL(6, withArgX);
+}
+
+namespace
+{
+  class MyClass
+  {
+  public:
+    MyClass()
+    {
+    }
+
+    MyClass(const MyClass& other)
+    {
+    }
+
+    MyClass(MyClass&& other)
+    {
+    }
+  };
+}
+
+TESTCASE(constructor_copy)
+{
+  Class c = define_class<MyClass>("MyClass")
+    .define_constructor(Constructor<MyClass>())
+    .define_constructor(Constructor<MyClass, const MyClass&>());
+
+  // Default constructor
+  Object o1 = c.call("new");
+  ASSERT_EQUAL(c, o1.class_of());
+
+  // Copy constructor
+  Object o2 = c.call("new", o1);
+  ASSERT_EQUAL(c, o2.class_of());
+}
+
+TESTCASE(constructor_move)
+{
+  Class c = define_class<MyClass>("MyClass")
+    .define_constructor(Constructor<MyClass>())
+    .define_constructor(Constructor<MyClass, MyClass&&>());
+
+  // Default constructor
+  Object o1 = c.call("new");
+  ASSERT_EQUAL(c, o1.class_of());
+
+  // Move constructor
+  Object o2 = c.call("new", o1);
+  ASSERT_EQUAL(c, o2.class_of());
 }

--- a/test/test_Module.cpp
+++ b/test/test_Module.cpp
@@ -59,27 +59,51 @@ TESTCASE(add_handler)
 
 namespace
 {
+  class MyClass
+  {
+  public:
+    MyClass() = default;
+  };
 
-bool some_function()
-{
-  return true;
-}
+  bool some_function()
+  {
+    return true;
+  }
 
-Object some_method(Object o)
-{
-  return o;
-}
+  Object some_method(Object o)
+  {
+    return o;
+  }
 
-int function_int(int i)
-{
-  return i;
-}
+  int function_int(int i)
+  {
+    return i;
+  }
 
-int method_int(Object object, int i)
-{
-  return i;
-}
+  int method_int(Object object, int i)
+  {
+    return i;
+  }
 
+  bool method_lvalue(MyClass& myClass)
+  {
+    return true;
+  }
+
+  bool method_rvalue(MyClass&& myClass)
+  {
+    return true;
+  }
+
+  void method_lvalue_return_void(int a, MyClass& myClass)
+  {
+    // Do nothing
+  }
+
+  void method_rvalue_return_void(int b, MyClass&& myClass)
+  {
+    // Do nothing
+  }
 } // namespace
 
 TESTCASE(define_method)
@@ -515,4 +539,36 @@ TESTCASE(references)
   ASSERT_EQUAL(boolValue, true);
   ASSERT_EQUAL(floatValue, 43.0);
   ASSERT_EQUAL(doubleValue, 44.0);
+}
+
+TESTCASE(lvalue_function)
+{
+  Module m(anonymous_module());
+  Class c = define_class<MyClass>("MyClass").
+            define_constructor(Constructor<MyClass>());
+
+  m.define_module_function("method_lvalue", &method_lvalue);
+  m.define_module_function("method_lvalue_return_void", &method_lvalue_return_void);
+
+  Object result = m.module_eval(R"(o = MyClass.new
+                                           method_lvalue_return_void(1, o)
+                                           method_lvalue(o))");
+
+  ASSERT_EQUAL(Qtrue, result.value());
+}
+
+TESTCASE(rvalue_function)
+{
+  Module m(anonymous_module());
+  Class c = define_class<MyClass>("MyClass").
+            define_constructor(Constructor<MyClass>());
+
+  m.define_module_function("method_rvalue", &method_rvalue);
+  m.define_module_function("method_rvalue_return_void", &method_rvalue_return_void);
+
+  Object result = m.module_eval(R"(o = MyClass.new
+                                       method_rvalue_return_void(1, o)
+                                       method_rvalue(o))");
+
+  ASSERT_EQUAL(Qtrue, result.value());
 }


### PR DESCRIPTION
Turns out Rice did not support passing rvalues as function/method parameters. Probably the most common use case for this is wrapping move constructors and move assignments.