### PR TITLE
Fix void pointers

### DIFF
--- a/rice/Data_Type.ipp
+++ b/rice/Data_Type.ipp
@@ -19,7 +19,7 @@
 namespace Rice
 {
   template<typename T>
-  void ruby_mark_internal(detail::Wrapper* wrapper)
+  inline void ruby_mark_internal(detail::Wrapper* wrapper)
   {
     // Tell the wrapper to mark the objects its keeping alive
     wrapper->ruby_mark();
@@ -30,15 +30,21 @@ namespace Rice
   }
 
   template<typename T>
-  void ruby_free_internal(detail::Wrapper* wrapper)
+  inline void ruby_free_internal(detail::Wrapper* wrapper)
   {
     delete wrapper;
   }
 
   template<typename T>
-  size_t ruby_size_internal(const T* data)
+  inline size_t ruby_size_internal(const T* data)
   {
     return sizeof(T);
+  }
+
+  template<>
+  inline size_t ruby_size_internal(const void* data)
+  {
+    return sizeof(void*);
   }
 
   template<typename T>

--- a/rice/detail/InstanceRegistry.hpp
+++ b/rice/detail/InstanceRegistry.hpp
@@ -14,6 +14,7 @@ namespace Rice::detail
 
     template <typename T>
     VALUE lookup(T* cppInstance);
+    VALUE lookup(void* cppInstance);
 
     void add(void* cppInstance, VALUE rubyInstance);
     void remove(void* cppInstance);
@@ -23,7 +24,6 @@ namespace Rice::detail
     bool isEnabled = false;
 
   private:
-    VALUE lookup(void* cppInstance);
     std::map<void*, VALUE> objectMap_;
   };
 } // namespace Rice::detail

--- a/rice/detail/TypeRegistry.ipp
+++ b/rice/detail/TypeRegistry.ipp
@@ -13,6 +13,22 @@ namespace Rice::detail
     registry_[key] = std::pair(klass, rbType);
   }
 
+  /* Special case void. Rice defines classes using the class name not a pointer to the
+     class. Thus define_class<void> is more consistent with Rice then 
+     define_class<void*>. However, the types of void and void* are different so we need
+     this special case.
+     
+     It is possible to support define_class<void*>, but it requires changing the static
+     assertions on Data_Type and Data_Object and thus seems less desirable (and less 
+     consistent as mentioned above).*/
+  template <>
+  inline void TypeRegistry::add<void>(VALUE klass, rb_data_type_t* rbType)
+  {
+    // The special case, use void*
+    std::type_index key(typeid(void*));
+    registry_[key] = std::pair(klass, rbType);
+  }
+
   template <typename T>
   inline void TypeRegistry::remove()
   {


### PR DESCRIPTION
Fix void pointers. Previously Rice could not send a wrap C++ object back to C++ via a void method parameter.