### PR TITLE
Attribute Setters

### DIFF
--- a/rice/Data_Type.ipp
+++ b/rice/Data_Type.ipp
@@ -267,9 +267,14 @@ namespace Rice
     if (access == AttrAccess::ReadWrite || access == AttrAccess::Read)
       detail::NativeAttributeGet<Attribute_T>::define(klass_, name, std::forward<Attribute_T>(attribute));
 
-    // Define native attribute setter
-    if (access == AttrAccess::ReadWrite || access == AttrAccess::Write)
-      detail::NativeAttributeSet<Attribute_T>::define(klass_, name, std::forward<Attribute_T>(attribute));
+    using Attr_T = typename detail::NativeAttributeSet<Attribute_T>::Attr_T;
+    if constexpr (!std::is_const_v<Attr_T> &&
+                  (std::is_fundamental_v<Attr_T> || std::is_assignable_v<Attr_T, Attr_T>))
+        {
+      // Define native attribute setter
+      if (access == AttrAccess::ReadWrite || access == AttrAccess::Write)
+        detail::NativeAttributeSet<Attribute_T>::define(klass_, name, std::forward<Attribute_T>(attribute));
+    }
 
     return *this;
   }

--- a/rice/detail/NativeAttributeSet.hpp
+++ b/rice/detail/NativeAttributeSet.hpp
@@ -13,11 +13,10 @@ namespace Rice
     {
     public:
       using NativeAttribute_T = NativeAttributeSet<Attribute_T>;
-
-      using T = typename attribute_traits<Attribute_T>::attr_type;
-      using T_Unqualified = remove_cv_recursive_t<T>;
+      using Attr_T = typename attribute_traits<Attribute_T>::attr_type;
+      using T_Unqualified = remove_cv_recursive_t<Attr_T>;
       using Receiver_T = typename attribute_traits<Attribute_T>::class_type;
-    
+
     public:
       // Register attribute getter/setter with Ruby
       static void define(VALUE klass, std::string name, Attribute_T attribute);

--- a/rice/detail/NativeAttributeSet.ipp
+++ b/rice/detail/NativeAttributeSet.ipp
@@ -15,11 +15,6 @@ namespace Rice::detail
     NativeAttribute_T* nativeAttribute = new NativeAttribute_T(klass, name, std::forward<Attribute_T>(attribute));
     std::unique_ptr<Native> native(nativeAttribute);
 
-    if (std::is_const_v<std::remove_pointer_t<T>>)
-    {
-      throw std::runtime_error(name + " is readonly");
-    }
-
     // Define the write method name
     std::string setter = name + "=";
 
@@ -51,30 +46,39 @@ namespace Rice::detail
   template<typename Attribute_T>
   inline VALUE NativeAttributeSet<Attribute_T>::operator()(int argc, VALUE* argv, VALUE self)
   {
-    if constexpr (std::is_fundamental_v<intrinsic_type<T>> && std::is_pointer_v<T>)
+    if constexpr (std::is_fundamental_v<intrinsic_type<Attr_T>> && std::is_pointer_v<Attr_T>)
     {
-      static_assert(true, "An fundamental value, such as an integer, cannot be assigned to an attribute that is a pointer");
+      static_assert(true, "An fundamental value, such as an integer, cannot be assigned to an attribute that is a pointer.");
     }
-    else if constexpr (std::is_same_v<intrinsic_type<T>, std::string> && std::is_pointer_v<T>)
+    else if constexpr (std::is_same_v<intrinsic_type<Attr_T>, std::string> && std::is_pointer_v<Attr_T>)
     {
-      static_assert(true, "An string cannot be assigned to an attribute that is a pointer");
+      static_assert(true, "An string cannot be assigned to an attribute that is a pointer.");
     }
 
     if (argc != 1)
     {
-      throw std::runtime_error("Incorrect number of parameter set to attribute writer");
+      throw std::runtime_error("Incorrect number of parameters for setting attribute. Attribute: " + this->name_);
     }
 
     VALUE value = argv[0];
     
-    if constexpr (!std::is_null_pointer_v<Receiver_T>)
+    if constexpr (!std::is_null_pointer_v<Receiver_T> && 
+                  !std::is_const_v<Attr_T> && 
+                  (std::is_fundamental_v<Attr_T> || std::is_assignable_v<Attr_T, Attr_T>))
     {
       Receiver_T* nativeSelf = From_Ruby<Receiver_T*>().convert(self);
       nativeSelf->*attribute_ = From_Ruby<T_Unqualified>().convert(value);
     }
-    else if constexpr (!std::is_const_v<std::remove_pointer_t<T>>)
+    else if constexpr (std::is_null_pointer_v<Receiver_T> && 
+                       !std::is_const_v<Attr_T> &&
+                       (std::is_fundamental_v<Attr_T> || std::is_assignable_v<Attr_T, Attr_T>))
     {
       *attribute_ = From_Ruby<T_Unqualified>().convert(value);
+    }
+    else
+    {
+      // Should never get here because define_attr won't compile this code, but just in case!
+      throw std::invalid_argument("Could not set attribute. Attribute: " + this->name_);
     }
 
     return value;


### PR DESCRIPTION
Do not generate invalid setter methods for attributes that are either constant or not assignable (ie, operator= is deleted or not public).