### PR TITLE
Update To_Ruby Type handling

### DIFF
--- a/rice/detail/NativeAttributeGet.hpp
+++ b/rice/detail/NativeAttributeGet.hpp
@@ -22,9 +22,9 @@ namespace Rice
       using NativeAttribute_T = NativeAttributeGet<Attribute_T>;
 
       using T = typename attribute_traits<Attribute_T>::attr_type;
-      using T_Unqualified = remove_cv_recursive_t<T>;
       using Receiver_T = typename attribute_traits<Attribute_T>::class_type;
-    
+      using To_Ruby_T = remove_cv_recursive_t<T>;
+
     public:
       // Register attribute getter with Ruby
       static void define(VALUE klass, std::string name, Attribute_T attribute);

--- a/rice/detail/NativeAttributeGet.ipp
+++ b/rice/detail/NativeAttributeGet.ipp
@@ -45,11 +45,11 @@ namespace Rice::detail
     if constexpr (std::is_member_object_pointer_v<Attribute_T>)
     {
       Receiver_T* nativeSelf = From_Ruby<Receiver_T*>().convert(self);
-      return To_Ruby<T_Unqualified>().convert(nativeSelf->*attribute_);
+      return To_Ruby<To_Ruby_T>().convert(nativeSelf->*attribute_);
     }
     else
     {
-      return To_Ruby<T_Unqualified>().convert(*attribute_);
+      return To_Ruby<To_Ruby_T>().convert(*attribute_);
     }
   }
 } // Rice

--- a/rice/detail/NativeFunction.ipp
+++ b/rice/detail/NativeFunction.ipp
@@ -59,16 +59,16 @@ namespace Rice::detail
   }
 
   template<typename Class_T, typename Function_T, bool IsMethod>
-  To_Ruby<typename NativeFunction<Class_T, Function_T, IsMethod>::Return_T> NativeFunction<Class_T, Function_T, IsMethod>::createToRuby()
+  To_Ruby<typename NativeFunction<Class_T, Function_T, IsMethod>::To_Ruby_T> NativeFunction<Class_T, Function_T, IsMethod>::createToRuby()
   {
     // Does the From_Ruby instantiation work with ReturnInfo?
-    if constexpr (std::is_constructible_v<To_Ruby<Return_T>, Return*>)
+    if constexpr (std::is_constructible_v<To_Ruby<To_Ruby_T>, Return*>)
     {
-      return To_Ruby<Return_T>(&this->methodInfo_->returnInfo);
+      return To_Ruby<To_Ruby_T>(&this->methodInfo_->returnInfo);
     }
     else
     {
-      return To_Ruby<Return_T>();
+      return To_Ruby<To_Ruby_T>();
     }
   }
 
@@ -227,7 +227,7 @@ namespace Rice::detail
     }
     else
     {
-      Return_T nativeResult = (Return_T)std::apply(this->function_, std::forward<decltype(selfAndNativeArgs)>(selfAndNativeArgs));
+      Return_T nativeResult = std::apply(this->function_, std::forward<decltype(selfAndNativeArgs)>(selfAndNativeArgs));
 
       // Special handling if the method returns self. If so we do not want
       // to create a new Ruby wrapper object and instead return self.

--- a/rice/detail/NativeIterator.hpp
+++ b/rice/detail/NativeIterator.hpp
@@ -13,7 +13,9 @@ namespace Rice::detail
     using NativeIterator_T = NativeIterator<T, Iterator_Func_T>;
     using Iterator_T = typename function_traits<Iterator_Func_T>::return_type;
     using Value_T = typename std::iterator_traits<Iterator_T>::value_type;
+    using Reference_T = typename std::iterator_traits<Iterator_T>::reference;
     using Difference_T = typename std::iterator_traits<Iterator_T>::difference_type;
+    using To_Ruby_T = remove_cv_recursive_t<Reference_T>;
 
   public:
     // Register function with Ruby

--- a/rice/detail/NativeIterator.ipp
+++ b/rice/detail/NativeIterator.ipp
@@ -90,7 +90,7 @@ namespace Rice::detail
 
       for (; it != end; ++it)
       {
-        protect(rb_yield, detail::To_Ruby<Value_T&>().convert(*it));
+        protect(rb_yield, detail::To_Ruby<To_Ruby_T>().convert(*it));
       }
 
       return self;

--- a/rice/stl/map.ipp
+++ b/rice/stl/map.ipp
@@ -1,4 +1,5 @@
 #include "../traits/function_traits.hpp"
+#include "../traits/rice_traits.hpp"
 #include "../detail/from_ruby.hpp"
 #include "../detail/to_ruby.hpp"
 #include "../detail/RubyFunction.hpp"
@@ -23,8 +24,10 @@ namespace Rice
       using Key_T = typename T::key_type;
       using Mapped_T = typename T::mapped_type;
       using Value_T = typename T::value_type;
+      using Reference_T = typename T::reference;
       using Size_T = typename T::size_type;
       using Difference_T = typename T::difference_type;
+      using To_Ruby_T = typename detail::remove_cv_recursive_t<Mapped_T>;
 
     public:
       MapHelper(Data_Type<T> klass) : klass_(klass)
@@ -194,10 +197,10 @@ namespace Rice
         klass_.define_method("to_h", [](T& map)
         {
           VALUE result = rb_hash_new();
-          std::for_each(map.begin(), map.end(), [&result](const typename T::reference pair)
+          std::for_each(map.begin(), map.end(), [&result](const Reference_T pair)
           {
             VALUE key = detail::To_Ruby<Key_T&>().convert(pair.first);
-            VALUE value = detail::To_Ruby<Mapped_T&>().convert(pair.second);
+            VALUE value = detail::To_Ruby<To_Ruby_T&>().convert(pair.second);
             rb_hash_aset(result, key, value);
           });
 

--- a/rice/stl/unordered_map.ipp
+++ b/rice/stl/unordered_map.ipp
@@ -1,4 +1,5 @@
 #include "../traits/function_traits.hpp"
+#include "../traits/rice_traits.hpp"
 #include "../detail/from_ruby.hpp"
 #include "../detail/to_ruby.hpp"
 #include "../detail/RubyFunction.hpp"
@@ -20,8 +21,10 @@ namespace Rice
       using Key_T = typename T::key_type;
       using Mapped_T = typename T::mapped_type;
       using Value_T = typename T::value_type;
+      using Reference_T = typename T::reference;
       using Size_T = typename T::size_type;
       using Difference_T = typename T::difference_type;
+      using To_Ruby_T = typename detail::remove_cv_recursive_t<Mapped_T>;
 
     public:
       UnorderedMapHelper(Data_Type<T> klass) : klass_(klass)
@@ -191,10 +194,10 @@ namespace Rice
         klass_.define_method("to_h", [](T& unordered_map)
         {
           VALUE result = rb_hash_new();
-          std::for_each(unordered_map.begin(), unordered_map.end(), [&result](const auto& pair)
+          std::for_each(unordered_map.begin(), unordered_map.end(), [&result](const Reference_T& pair)
           {
-            VALUE key = detail::To_Ruby<Key_T>().convert(pair.first);
-            VALUE value = detail::To_Ruby<Mapped_T>().convert(pair.second);
+            VALUE key = detail::To_Ruby<Key_T&>().convert(pair.first);
+            VALUE value = detail::To_Ruby<To_Ruby_T&>().convert(pair.second);
             rb_hash_aset(result, key, value);
           });
 


### PR DESCRIPTION
Make To_Ruby type handling more consistent and change NativeFunction::Return_T back to the actual return type of the function. These changes fix compilation issues with OpenCV.