### PR TITLE
Support pointers to pointers

### DIFF
--- a/rice/Data_Object.ipp
+++ b/rice/Data_Object.ipp
@@ -282,7 +282,7 @@ namespace Rice::detail
       {
         // Note that T could be a pointer or reference to a base class while data is in fact a
         // child class. Lookup the correct type so we return an instance of the correct Ruby class
-        std::pair<VALUE, rb_data_type_t*> rubyTypeInfo = detail::Registries::instance.types.figureType(*data);
+        std::pair<VALUE, rb_data_type_t*> rubyTypeInfo = detail::Registries::instance.types.figureType(**data);
         bool isOwner = this->returnInfo_ && this->returnInfo_->isOwner();
         return detail::wrap(rubyTypeInfo.first, rubyTypeInfo.second, data, isOwner);
       }

--- a/rice/detail/NativeFunction.hpp
+++ b/rice/detail/NativeFunction.hpp
@@ -89,6 +89,9 @@ namespace Rice::detail
     // Convert Ruby argv pointer to Ruby values
     std::vector<VALUE> getRubyValues(int argc, VALUE* argv);
 
+    template<typename Arg_T, int I>
+    Arg_T getNativeValue(std::vector<VALUE>& values);
+
     // Convert Ruby values to C++ values
     template<typename std::size_t...I>
     Arg_Ts getNativeValues(std::vector<VALUE>& values, std::index_sequence<I...>& indices);

--- a/rice/traits/rice_traits.hpp
+++ b/rice/traits/rice_traits.hpp
@@ -113,6 +113,25 @@ namespace Rice
     {
       using type = std::tuple<T<remove_cv_recursive_t<Arg_Ts>>...>;
     };
+
+    template<class T>
+    struct is_pointer_pointer : std::false_type {};
+
+    template<class T>
+    struct is_pointer_pointer<T**> : std::true_type {};
+
+    template<class T>
+    struct is_pointer_pointer<T** const> : std::true_type {};
+
+    template<class T>
+    struct is_pointer_pointer<T* const * const> : std::true_type {};
+
+    template<class T>
+    struct is_pointer_pointer<const T* const* const> : std::true_type {};
+
+    template<class T>
+    constexpr bool is_pointer_pointer_v = is_pointer_pointer<T>::value;
+
   } // detail
 } // Rice
 


### PR DESCRIPTION
This is needed for creating OpenCV bindings. Its a bit of an ugly hack, but seems better than the alternative of updating From_Ruby# convert method to take an additional template parameter to control (which is not a backwards compatible change).