### PR TITLE
Improve Type Verification

### DIFF
--- a/rice/Data_Type.ipp
+++ b/rice/Data_Type.ipp
@@ -191,8 +191,8 @@ namespace Rice
   {
     if (!is_bound())
     {
-      std::string message = "Type " + detail::typeName(typeid(T)) + " is not bound";
-      throw std::runtime_error(message.c_str());
+      std::string message = "Type is not defined with Rice: " + detail::typeName(typeid(T));
+      throw std::invalid_argument(message.c_str());
     }
   }
 

--- a/rice/detail/Registries.ipp
+++ b/rice/detail/Registries.ipp
@@ -2,22 +2,4 @@ namespace Rice::detail
 {
   //Initialize static variables here.
   inline Registries Registries::instance;
-
-  // TODO - Big hack here but this code is dependent on internals
-  template<typename T>
-  bool Type<T>::verify()
-  {
-    // Use intrinsic_type so that we don't have to define specializations
-    // for pointers, references, const, etc.
-    using Intrinsic_T = intrinsic_type<T>;
-
-    if constexpr (std::is_fundamental_v<Intrinsic_T>)
-    {
-      return true;
-    }
-    else
-    {
-      return Registries::instance.types.verifyDefined<Intrinsic_T>();
-    }
-  }
 }

--- a/rice/detail/Type.hpp
+++ b/rice/detail/Type.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <typeinfo>
+#include <typeindex>
 #include "../traits/rice_traits.hpp"
 
 namespace Rice::detail
@@ -15,6 +16,7 @@ namespace Rice::detail
 
   // Return the name of a type
   std::string typeName(const std::type_info& typeInfo);
+  std::string typeName(const std::type_index& typeIndex);
   std::string makeClassName(const std::type_info& typeInfo);
 
   template<typename T>
@@ -23,7 +25,5 @@ namespace Rice::detail
   template<typename Tuple_T>
   void verifyTypes();
 }
-
-#include "Type.ipp"
 
 #endif // Rice__Type__hpp_

--- a/rice/detail/Type.ipp
+++ b/rice/detail/Type.ipp
@@ -1,4 +1,5 @@
 #include "../traits/rice_traits.hpp"
+#include "Registries.hpp"
 
 #include <iosfwd>
 #include <iterator>
@@ -15,6 +16,19 @@
 
 namespace Rice::detail
 {
+  template<typename T>
+  bool Type<T>::verify()
+  {
+    if constexpr (std::is_fundamental_v<T>)
+    {
+      return true;
+    }
+    else
+    {
+      return Registries::instance.types.verify<T>();
+    }
+  }
+
   template<>
   struct Type<void>
   {
@@ -87,6 +101,11 @@ namespace Rice::detail
   inline std::string typeName(const std::type_info& typeInfo)
   {
     return demangle(typeInfo.name());
+  }
+
+  inline std::string typeName(const std::type_index& typeIndex)
+  {
+    return demangle(typeIndex.name());
   }
 
   inline std::string makeClassName(const std::type_info& typeInfo)

--- a/rice/detail/TypeRegistry.hpp
+++ b/rice/detail/TypeRegistry.hpp
@@ -6,6 +6,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <unordered_map>
+#include <set>
 
 #include "ruby.hpp"
 
@@ -31,14 +32,22 @@ namespace Rice::detail
     bool isDefined();
 
     template <typename T>
-    bool verifyDefined();
+    bool verify();
       
     template <typename T>
     std::pair<VALUE, rb_data_type_t*> figureType(const T& object);
 
+    // Validate unverified types and throw an exception if any exist. This is mostly for unit tests.
+    void validateUnverifiedTypes();
+    // Clear unverified types. This is mostly for unit tests
+    void clearUnverifiedTypes();
   private:
     std::optional<std::pair<VALUE, rb_data_type_t*>> lookup(const std::type_info& typeInfo);
+    void raiseUnverifiedType(const std::string& typeName);
+
     std::unordered_map<std::type_index, std::pair<VALUE, rb_data_type_t*>> registry_{};
+    std::set<std::type_index> unverified_{};
+    bool verified_ = true;
   };
 }
 

--- a/rice/rice.hpp
+++ b/rice/rice.hpp
@@ -29,6 +29,7 @@
 #include "detail/HandlerRegistry.hpp"
 #include "detail/NativeRegistry.hpp"
 #include "detail/Registries.hpp"
+#include "detail/Type.ipp"
 #include "detail/cpp_protect.hpp"
 #include "detail/Wrapper.hpp"
 #include "detail/MethodInfo.hpp"

--- a/rice/traits/rice_traits.hpp
+++ b/rice/traits/rice_traits.hpp
@@ -10,9 +10,10 @@ namespace Rice
 {
   namespace detail
   {
-    // Get the base_type of T - without pointer, reference, const or volatile
+    // Get the base_type of T - without pointer, reference, const or volatile. We call remove_pointer_t twice 
+    // for T**
     template<typename T>
-    using intrinsic_type = typename std::remove_cv_t<std::remove_pointer_t<std::remove_reference_t<T>>>;
+    using intrinsic_type = typename std::remove_cv_t<std::remove_pointer_t<std::remove_pointer_t<std::remove_reference_t<T>>>>;
 
     // Recursively remove const/volatile
     template<typename T>


### PR DESCRIPTION
It turns out immediate Type verification when calling define_method, define_attr, define_enum, define_iter doesn't work on large C++ code bases because of C++ forwarding support.

Therefore instead of immediately failing, this commit updates the TypeRegistry to track undefined types. Then when figure_type is called for the first time, which will happen when Ruby calls a C++ function that returns an object, the TypeRegistry will check the undefined types. If any still remain undefined, because they are not in the list of defined types, it will throw will throw an exception.

So if an exception is thrown it should hopefully happen almost immediately at program startup and not at some random point in the future when a method with an undefined type is called.