### PR TITLE
Transfer Ownership from Ruby to C++

### DIFF
--- a/rice/Arg.hpp
+++ b/rice/Arg.hpp
@@ -67,6 +67,10 @@ namespace Rice
     //! Returns if the argument should be treated as a value
     bool isValue() const;
 
+    //! Specifies C++ will take ownership of this value and Ruby shoudl not fee it
+    Arg& transferOwnership();
+    bool isTransfer();
+
   public:
     const std::string name;
     int32_t position = -1;
@@ -76,6 +80,7 @@ namespace Rice
     std::any defaultValue_;
     bool isValue_ = false;
     bool isKeepAlive_ = false;
+    bool isTransfer_ = false;
   };
 } // Rice
 

--- a/rice/Arg.ipp
+++ b/rice/Arg.ipp
@@ -47,4 +47,17 @@ namespace Rice
   {
     return isValue_;
   }
+
+  inline Arg& Arg::transferOwnership()
+  {
+    this->isTransfer_ = true;
+    return *this;
+  }
+
+  inline bool Arg::isTransfer()
+  {
+    return this->isTransfer_;
+  }
+
+
 } // Rice

--- a/rice/Data_Object.ipp
+++ b/rice/Data_Object.ipp
@@ -65,16 +65,16 @@ namespace Rice
     }
     else
     {
-      return detail::unwrap<T>(this->value(), Data_Type<T>::ruby_data_type());
+      return detail::unwrap<T>(this->value(), Data_Type<T>::ruby_data_type(), false);
     }
   }
 
   template<typename T>
-  inline T* Data_Object<T>::from_ruby(VALUE value)
+  inline T* Data_Object<T>::from_ruby(VALUE value, bool transferOwnership)
   {
     if (Data_Type<T>::is_descendant(value))
     {
-      return detail::unwrap<T>(value, Data_Type<T>::ruby_data_type());
+      return detail::unwrap<T>(value, Data_Type<T>::ruby_data_type(), transferOwnership);
     }
     else
     {
@@ -356,7 +356,7 @@ namespace Rice::detail
       }
       else
       {
-        return *Data_Object<Intrinsic_T>::from_ruby(value);
+        return *Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
       }
     }
 
@@ -398,7 +398,7 @@ namespace Rice::detail
       }
       else
       {
-        return *Data_Object<Intrinsic_T>::from_ruby(value);
+        return *Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
       }
     }
 
@@ -440,7 +440,7 @@ namespace Rice::detail
       }
       else
       {
-        return std::move(*Data_Object<Intrinsic_T>::from_ruby(value));
+        return std::move(*Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer()));
       }
     }
 
@@ -454,6 +454,12 @@ namespace Rice::detail
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
   public:
+    From_Ruby() = default;
+
+    explicit From_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     Convertible is_convertible(VALUE value)
     {
       switch (rb_type(value))
@@ -479,9 +485,12 @@ namespace Rice::detail
       }
       else
       {
-        return Data_Object<Intrinsic_T>::from_ruby(value);
+        return Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
       }
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 
   template<typename T>
@@ -490,6 +499,12 @@ namespace Rice::detail
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
   public:
+    From_Ruby() = default;
+
+    explicit From_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     Convertible is_convertible(VALUE value)
     {
       switch (rb_type(value))
@@ -512,9 +527,12 @@ namespace Rice::detail
       }
       else
       {
-        return Data_Object<Intrinsic_T>::from_ruby(value);
+        return Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
       }
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 
   template<typename T>
@@ -523,6 +541,12 @@ namespace Rice::detail
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
   public:
+    From_Ruby() = default;
+
+    explicit From_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     Convertible is_convertible(VALUE value)
     {
       switch (rb_type(value))
@@ -545,9 +569,12 @@ namespace Rice::detail
       }
       else
       {
-        return detail::unwrap<Intrinsic_T*>(value, Data_Type<T>::ruby_data_type());
+        return detail::unwrap<Intrinsic_T*>(value, Data_Type<T>::ruby_data_type(), false);
       }
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 
   template<typename T>
@@ -566,6 +593,12 @@ namespace Rice::detail
   class From_Ruby<void*>
   {
   public:
+    From_Ruby() = default;
+
+    explicit From_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     Convertible is_convertible(VALUE value)
     {
       switch (rb_type(value))
@@ -591,7 +624,7 @@ namespace Rice::detail
           // Since C++ is not telling us type information, we need to extract it
           // from the Ruby object.
           const rb_data_type_t* rb_type = RTYPEDDATA_TYPE(value);
-          return detail::unwrap<void>(value, (rb_data_type_t*)rb_type);
+          return detail::unwrap<void>(value, (rb_data_type_t*)rb_type, this->arg_ && this->arg_->isTransfer());
           break;
         }
         case RUBY_T_NIL:
@@ -602,6 +635,8 @@ namespace Rice::detail
             detail::protect(rb_obj_classname, value), "pointer");
       }
     }
+  private:
+    Arg* arg_ = nullptr;
   };
 }
 #endif // Rice__Data_Object__ipp_

--- a/rice/Data_Object_defn.hpp
+++ b/rice/Data_Object_defn.hpp
@@ -48,7 +48,7 @@ namespace Rice
     static_assert(!std::is_void_v<T>);
 
   public:
-    static T* from_ruby(VALUE value);
+    static T* from_ruby(VALUE value, bool transferOwnership = false);
 
   public:
     //! Wrap a C++ object.

--- a/rice/detail/Wrapper.hpp
+++ b/rice/detail/Wrapper.hpp
@@ -11,11 +11,16 @@ namespace detail
 class Wrapper
 {
 public:
+  Wrapper(bool isOwner = false);
   virtual ~Wrapper() = default;
   virtual void* get() = 0;
 
   void ruby_mark();
   void addKeepAlive(VALUE value);
+  void setOwner(bool value);
+
+protected:
+  bool isOwner_ = false;
 
 private:
   // We use a vector for speed and memory locality versus a set which does
@@ -31,7 +36,7 @@ template <typename T, typename Wrapper_T = void>
 VALUE wrap(VALUE klass, rb_data_type_t* rb_type, T* data, bool isOwner);
 
 template <typename T>
-T* unwrap(VALUE value, rb_data_type_t* rb_type);
+T* unwrap(VALUE value, rb_data_type_t* rb_type, bool transferOwnership);
 
 Wrapper* getWrapper(VALUE value, rb_data_type_t* rb_type);
 

--- a/test/test_Data_Object.cpp
+++ b/test/test_Data_Object.cpp
@@ -69,7 +69,7 @@ TESTCASE(construct_from_pointer)
   Data_Object<MyDataType> wrapped_foo(myDataType);
   ASSERT_EQUAL(myDataType, wrapped_foo.get());
   ASSERT_EQUAL(Data_Type<MyDataType>::klass(), wrapped_foo.class_of());
-  ASSERT_EQUAL(myDataType, detail::unwrap<MyDataType>(wrapped_foo, Data_Type<MyDataType>::ruby_data_type()));
+  ASSERT_EQUAL(myDataType, detail::unwrap<MyDataType>(wrapped_foo, Data_Type<MyDataType>::ruby_data_type(), false));
 }
 
 TESTCASE(construct_from_ruby_object)
@@ -81,7 +81,7 @@ TESTCASE(construct_from_ruby_object)
   ASSERT_EQUAL(myDataType, data_object_foo.get());
   ASSERT_EQUAL(Data_Type<MyDataType>::klass(), data_object_foo.class_of());
   ASSERT_EQUAL(RTYPEDDATA(wrapped_foo), RTYPEDDATA(data_object_foo.value()));
-  ASSERT_EQUAL(myDataType, detail::unwrap<MyDataType>(wrapped_foo, Data_Type<MyDataType>::ruby_data_type()));
+  ASSERT_EQUAL(myDataType, detail::unwrap<MyDataType>(wrapped_foo, Data_Type<MyDataType>::ruby_data_type(), false));
 }
 
 TESTCASE(construct_from_ruby_object_and_wrong_class)
@@ -110,7 +110,7 @@ TESTCASE(copy_construct)
   ASSERT_EQUAL(myDataType, data_object_foo.get());
   ASSERT_EQUAL(Data_Type<MyDataType>::klass(), data_object_foo.class_of());
   ASSERT_EQUAL(RTYPEDDATA(wrapped_foo), RTYPEDDATA(data_object_foo.value()));
-  ASSERT_EQUAL(myDataType, detail::unwrap<MyDataType>(wrapped_foo, Data_Type<MyDataType>::ruby_data_type()));
+  ASSERT_EQUAL(myDataType, detail::unwrap<MyDataType>(wrapped_foo, Data_Type<MyDataType>::ruby_data_type(), false));
 }
 
 TESTCASE(move_construct)


### PR DESCRIPTION
Add ability to transfer ownership from Ruby to C++. This doesn't happen much, but can happen when dealing with APIs that take smart pointers and Ruby only has a raw pointer.