### PR TITLE
Improved Callback Support

### DIFF
--- a/rice/Arg.hpp
+++ b/rice/Arg.hpp
@@ -35,6 +35,9 @@ namespace Rice
      */
     Arg(std::string name);
 
+    // Make Arg polymorphic so dynamic_cast works
+    virtual ~Arg() = default;
+
     //! Set the default value for this Arg
     /*! Set the default value for this argument.
      *  If this isn't called on this Arg, then this
@@ -56,23 +59,30 @@ namespace Rice
 
     //! Tell the receiving object to keep this argument alive
     //! until the receiving object is freed.
-    Arg& keepAlive();
+    virtual Arg& keepAlive();
     
     //! Returns if the argument should be kept alive
     bool isKeepAlive() const;
 
     //! Specifies if the argument should be treated as a value
-    Arg& setValue();
+    virtual Arg& setValue();
 
     //! Returns if the argument should be treated as a value
     bool isValue() const;
 
+    //! Specifies if the argument is opaque and Rice should not convert it from Ruby to C++ or vice versa.
+    //! This is useful for callbacks and user provided data paramameters.
+    virtual Arg& setOpaque();
+
+    //! Returns if the argument should be treated as a value
+    bool isOpaque() const;
+
     //! Specifies C++ will take ownership of this value and Ruby should not free it
-    Arg& transferOwnership();
-    bool isTransfer();
+    virtual Arg& takeOwnership();
+    bool isOwner();
 
   public:
-    const std::string name;
+    std::string name;
     int32_t position = -1;
 
   private:
@@ -80,7 +90,8 @@ namespace Rice
     std::any defaultValue_;
     bool isValue_ = false;
     bool isKeepAlive_ = false;
-    bool isTransfer_ = false;
+    bool isOwner_ = false;
+    bool isOpaque_ = false;
   };
 } // Rice
 

--- a/rice/Arg.ipp
+++ b/rice/Arg.ipp
@@ -48,15 +48,26 @@ namespace Rice
     return isValue_;
   }
 
-  inline Arg& Arg::transferOwnership()
+  inline Arg& Arg::setOpaque()
   {
-    this->isTransfer_ = true;
+    isOpaque_ = true;
     return *this;
   }
 
-  inline bool Arg::isTransfer()
+  inline bool Arg::isOpaque() const
   {
-    return this->isTransfer_;
+    return isOpaque_;
+  }
+
+  inline Arg& Arg::takeOwnership()
+  {
+    this->isOwner_ = true;
+    return *this;
+  }
+
+  inline bool Arg::isOwner()
+  {
+    return this->isOwner_;
   }
 
 

--- a/rice/Callback.hpp
+++ b/rice/Callback.hpp
@@ -1,0 +1,21 @@
+#ifndef Rice__Callback__hpp_
+#define Rice__Callback__hpp_
+
+namespace Rice
+{
+  //! Define a callback.
+  /*! When C++ invokes a C style callback, Rice automatically converts the C++ arguments
+   *  to Ruby. However, there may be cases where you need to specify how individual arguments
+   *  should be handled. For example, callbacks often have a user data parameter which is 
+   *  defined as a void pointer (void*). In this case, you need to tell Ruby that the parameter
+   *  is opaque and should not be convered. For example:
+   * 
+   *  define_callback<void(*)(void*)>(Arg("user_data").setOpaque());
+   *
+   *  \param args a list of Arg instance used to define default parameters (optional)
+   *  \return nothing
+   */
+  template<typename Callback_T, typename...Arg_Ts>
+  void define_callback(const Arg_Ts&...args);
+}
+#endif // Rice__Callback__hpp_

--- a/rice/Callback.ipp
+++ b/rice/Callback.ipp
@@ -1,0 +1,13 @@
+namespace Rice
+{
+  template<typename Callback_T, typename...Arg_Ts>
+  void define_callback(const Arg_Ts&...args)
+  {
+    MethodInfo* methodInfo = new MethodInfo(detail::function_traits<Callback_T>::arity, args...);
+  #ifdef HAVE_LIBFFI
+    detail::NativeCallbackFFI<Callback_T>::setMethodInfo(methodInfo);
+  #else
+    detail::NativeCallbackSimple<Callback_T>::setMethodInfo(methodInfo);
+  #endif
+  }
+}

--- a/rice/Data_Object.hpp
+++ b/rice/Data_Object.hpp
@@ -42,7 +42,7 @@ namespace Rice
     static_assert(!std::is_void_v<T>);
 
   public:
-    static T* from_ruby(VALUE value, bool transferOwnership = false);
+    static T* from_ruby(VALUE value, bool takeOwnership = false);
 
   public:
     //! Wrap a C++ object.

--- a/rice/Data_Object.ipp
+++ b/rice/Data_Object.ipp
@@ -73,11 +73,11 @@ namespace Rice
   }
 
   template<typename T>
-  inline T* Data_Object<T>::from_ruby(VALUE value, bool transferOwnership)
+  inline T* Data_Object<T>::from_ruby(VALUE value, bool takeOwnership)
   {
     if (Data_Type<T>::is_descendant(value))
     {
-      return detail::unwrap<T>(value, Data_Type<T>::ruby_data_type(), transferOwnership);
+      return detail::unwrap<T>(value, Data_Type<T>::ruby_data_type(), takeOwnership);
     }
     else
     {
@@ -187,41 +187,6 @@ namespace Rice::detail
       {
         return Qnil;
       }
-    }
-
-  private:
-    Return* returnInfo_ = nullptr;
-  };
-
-  template <>
-  class To_Ruby<void*>
-  {
-  public:
-    To_Ruby() = default;
-
-    explicit To_Ruby(Return* returnInfo) : returnInfo_(returnInfo)
-    {
-    }
-
-    VALUE convert(void* data)
-    {
-      if (data)
-      {
-        // Note that T could be a pointer or reference to a base class while data is in fact a
-        // child class. Lookup the correct type so we return an instance of the correct Ruby class
-        std::pair<VALUE, rb_data_type_t*> rubyTypeInfo = detail::Registries::instance.types.figureType(data);
-        bool isOwner = this->returnInfo_ && this->returnInfo_->isOwner();
-        return detail::wrap(rubyTypeInfo.first, rubyTypeInfo.second, data, isOwner);
-      }
-      else
-      {
-        return Qnil;
-      }
-    }
-
-    VALUE convert(const void* data)
-    {
-      return convert((void*)data);
     }
 
   private:
@@ -364,7 +329,7 @@ namespace Rice::detail
       }
       else
       {
-        return *Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
+        return *Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isOwner());
       }
     }
 
@@ -406,7 +371,7 @@ namespace Rice::detail
       }
       else
       {
-        return *Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
+        return *Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isOwner());
       }
     }
 
@@ -448,7 +413,7 @@ namespace Rice::detail
       }
       else
       {
-        return std::move(*Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer()));
+        return std::move(*Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isOwner()));
       }
     }
 
@@ -493,7 +458,7 @@ namespace Rice::detail
       }
       else
       {
-        return Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
+        return Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isOwner());
       }
     }
 
@@ -535,7 +500,7 @@ namespace Rice::detail
       }
       else
       {
-        return Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isTransfer());
+        return Data_Object<Intrinsic_T>::from_ruby(value, this->arg_ && this->arg_->isOwner());
       }
     }
 

--- a/rice/Return.hpp
+++ b/rice/Return.hpp
@@ -5,31 +5,15 @@ namespace Rice
 {
   //! Helper for defining Return argument of a method
 
-  class Return
+  class Return: public Arg
   {
   public:
-    //! Specifies Ruby should take ownership of the returned value
-    Return& takeOwnership();
+    Return();
+    Return& keepAlive() override;
+    Return& setValue() override;
+    Return& setOpaque() override;
+    Return& takeOwnership() override;
 
-    //! Does Ruby own the returned value?
-    bool isOwner();
-
-    //! Specifies the returned value is a Ruby value
-    Return& setValue();
-
-    //! Is the returned value a Ruby value?
-    bool isValue() const;
-
-    //! Tell the returned object to keep alive the receving object
-    Return& keepAlive();
-
-    //! Is the returned value being kept alive?
-    bool isKeepAlive() const;
-
-  private:
-    bool isKeepAlive_ = false;
-    bool isOwner_ = false;
-    bool isValue_ = false;
   };
 } // Rice
 

--- a/rice/Return.ipp
+++ b/rice/Return.ipp
@@ -2,36 +2,31 @@
 
 namespace Rice
 {
-  inline Return& Return::takeOwnership()
+  inline Return::Return(): Arg("Return")
   {
-    this->isOwner_ = true;
-    return *this;
-  }
-
-  inline bool Return::isOwner()
-  {
-    return this->isOwner_;
-  }
-
-  inline Return& Return::setValue()
-  {
-    this->isValue_ = true;
-    return *this;
-  }
-
-  inline bool Return::isValue() const
-  {
-    return this->isValue_;
   }
 
   inline Return& Return::keepAlive()
   {
-    this->isKeepAlive_ = true;
+    Arg::keepAlive();
     return *this;
   }
 
-  inline bool Return::isKeepAlive() const
+  inline Return& Return::setValue()
   {
-    return this->isKeepAlive_;
+    Arg::setValue();
+    return *this;
+  }
+
+  inline Return& Return::setOpaque()
+  {
+    Arg::setOpaque();
+    return *this;
+  }
+
+  inline Return& Return::takeOwnership()
+  {
+    Arg::takeOwnership();
+    return *this;
   }
 }  // Rice

--- a/rice/cpp_api/shared_methods.hpp
+++ b/rice/cpp_api/shared_methods.hpp
@@ -38,7 +38,7 @@ inline auto& define_method(std::string name, Function_T&& func, const Arg_Ts&...
   return *this;
 }
 
-//! Define an instance function.
+//! Define a function.
 /*! The function implementation is a plain function or a static
  *  member function.
  *  Rice will automatically convert method method from Ruby to C++ and

--- a/rice/detail/MethodInfo.hpp
+++ b/rice/detail/MethodInfo.hpp
@@ -8,6 +8,8 @@ namespace Rice
   class MethodInfo
   {
   public:
+    MethodInfo() = default;
+
     template <typename...Arg_Ts>
     MethodInfo(size_t argCount, const Arg_Ts&...args);
 
@@ -22,7 +24,7 @@ namespace Rice
       */
     void addArg(const Arg& arg);
 
-    Arg& arg(size_t pos);
+    Arg* arg(size_t pos);
 
     // Iterator support
     std::vector<Arg>::iterator begin();

--- a/rice/detail/MethodInfo.ipp
+++ b/rice/detail/MethodInfo.ipp
@@ -25,13 +25,13 @@ namespace Rice
   template <typename Arg_T>
   inline void MethodInfo::processArg(const Arg_T& arg)
   {
-    if constexpr (std::is_same_v<Arg_T, Arg>)
+    if constexpr (std::is_same_v<Arg_T, Return>)
     {
-      this->addArg(arg);
+      this->returnInfo = arg;
     }
     else
     {
-      this->returnInfo = arg;
+      this->addArg(arg);
     }
   }
 
@@ -60,9 +60,16 @@ namespace Rice
     return std::to_string(required) + std::to_string(optional);
   }
 
-  inline Arg& MethodInfo::arg(size_t pos)
+  inline Arg* MethodInfo::arg(size_t pos)
   {
-    return args_[pos];
+    if (pos < this->args_.size())
+    {
+      return &this->args_[pos];
+    }
+    else
+    {
+      return nullptr;
+    }
   }
 
   inline std::vector<Arg>::iterator MethodInfo::begin()

--- a/rice/detail/NativeCallbackSimple.hpp
+++ b/rice/detail/NativeCallbackSimple.hpp
@@ -3,12 +3,16 @@
 
 namespace Rice::detail
 {
+  template<typename Callback_T>
+  class NativeCallbackSimple;
+
   template<typename Return_T, typename ...Arg_Ts>
-  class NativeCallbackSimple
+  class NativeCallbackSimple<Return_T(*)(Arg_Ts...)>
   {
   public:
     static Return_T callback(Arg_Ts...args);
     static inline VALUE proc = Qnil;
+    static void setMethodInfo(MethodInfo* methodInfo);
 
   public:
     NativeCallbackSimple()  = delete;
@@ -16,6 +20,11 @@ namespace Rice::detail
     NativeCallbackSimple(NativeCallbackSimple&&) = delete;
     void operator=(const NativeCallbackSimple&) = delete;
     void operator=(NativeCallbackSimple&&) = delete;
+
+  private:
+    template<std::size_t... I>
+    static Return_T callRuby(std::index_sequence<I...>& indices, Arg_Ts...args);
+    static inline std::unique_ptr<MethodInfo> methodInfo_ = std::make_unique<MethodInfo>();
   };
 }
 #endif // Rice__detail__Native_Callback_Simple_hpp_

--- a/rice/detail/NativeCallbackSimple.ipp
+++ b/rice/detail/NativeCallbackSimple.ipp
@@ -1,15 +1,29 @@
 namespace Rice::detail
 {
   template<typename Return_T, typename ...Arg_Ts>
-  Return_T NativeCallbackSimple<Return_T, Arg_Ts...>::callback(Arg_Ts...args)
+  void NativeCallbackSimple<Return_T(*)(Arg_Ts...)>::setMethodInfo(MethodInfo* methodInfo)
+  {
+    methodInfo_.reset(methodInfo);
+  }
+
+  template<typename Return_T, typename ...Arg_Ts>
+  template<std::size_t... I>
+  Return_T NativeCallbackSimple<Return_T(*)(Arg_Ts...)>::callRuby(std::index_sequence<I...>& indices, Arg_Ts...args)
   {
     static Identifier id("call");
-    std::array<VALUE, sizeof...(Arg_Ts)> values = { detail::To_Ruby<detail::remove_cv_recursive_t<Arg_Ts>>().convert(args)... };
+    std::array<VALUE, sizeof...(Arg_Ts)> values = { detail::To_Ruby<detail::remove_cv_recursive_t<Arg_Ts>>(methodInfo_->arg(I)).convert(args)... };
     VALUE result = detail::protect(rb_funcallv, proc, id.id(), (int)sizeof...(Arg_Ts), values.data());
     if constexpr (!std::is_void_v<Return_T>)
     {
-      static From_Ruby<Return_T> fromRuby;
+      static From_Ruby<Return_T> fromRuby(dynamic_cast<Arg*>(&methodInfo_->returnInfo));
       return fromRuby.convert(result);
     }
+  }
+
+  template<typename Return_T, typename ...Arg_Ts>
+  Return_T NativeCallbackSimple<Return_T(*)(Arg_Ts...)>::callback(Arg_Ts...args)
+  {
+    auto indices = std::make_index_sequence<sizeof...(Arg_Ts)>{};
+    return NativeCallbackSimple<Return_T(*)(Arg_Ts...)>::callRuby(indices, args...);
   }
 }

--- a/rice/detail/NativeFunction.hpp
+++ b/rice/detail/NativeFunction.hpp
@@ -55,6 +55,7 @@ namespace Rice::detail
 
     // Proc entry
     static VALUE procEntry(VALUE yielded_arg, VALUE callback_arg, int argc, const VALUE* argv, VALUE blockarg);
+    static VALUE finalizerCallback(VALUE yielded_arg, VALUE callback_arg, int argc, const VALUE* argv, VALUE blockarg);
   public:
     // Disallow creating/copying/moving
     NativeFunction() = delete;

--- a/rice/detail/Wrapper.hpp
+++ b/rice/detail/Wrapper.hpp
@@ -34,7 +34,7 @@ template <typename T, typename Wrapper_T = void>
 VALUE wrap(VALUE klass, rb_data_type_t* rb_type, T* data, bool isOwner);
 
 template <typename T>
-T* unwrap(VALUE value, rb_data_type_t* rb_type, bool transferOwnership);
+T* unwrap(VALUE value, rb_data_type_t* rb_type, bool takeOwnership);
 
 Wrapper* getWrapper(VALUE value, rb_data_type_t* rb_type);
 

--- a/rice/detail/Wrapper.ipp
+++ b/rice/detail/Wrapper.ipp
@@ -174,10 +174,10 @@ namespace Rice::detail
   };
 
   template <typename T>
-  inline T* unwrap(VALUE value, rb_data_type_t* rb_type, bool transferOwnership)
+  inline T* unwrap(VALUE value, rb_data_type_t* rb_type, bool takeOwnership)
   {
     Wrapper* wrapper = getWrapper(value, rb_type);
-    if (transferOwnership)
+    if (takeOwnership)
       wrapper->setOwner(false);
 
     if (wrapper == nullptr)

--- a/rice/detail/from_ruby.ipp
+++ b/rice/detail/from_ruby.ipp
@@ -213,7 +213,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -316,7 +316,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -354,7 +354,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -457,7 +457,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -527,7 +527,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -630,7 +630,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -733,7 +733,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -847,7 +847,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -950,7 +950,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -1053,7 +1053,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -1160,7 +1160,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -1267,7 +1267,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -1377,7 +1377,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -1480,7 +1480,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -1583,7 +1583,7 @@ namespace Rice::detail
 
     ~From_Ruby()
     {
-      if (this->arg_ && this->arg_->isTransfer())
+      if (this->arg_ && this->arg_->isOwner())
       {
         this->converted_.release();
       }
@@ -1613,7 +1613,7 @@ namespace Rice::detail
 
     explicit From_Ruby(Arg* arg) : arg_(arg)
     {
-      if (this->arg_->isTransfer())
+      if (this->arg_->isOwner())
       {
         throw Exception(rb_eTypeError, "Cannot transfer ownership of string data to C++ void pointer");
       }
@@ -1621,6 +1621,11 @@ namespace Rice::detail
 
     Convertible is_convertible(VALUE value)
     {
+      if (this->arg_ && this->arg_->isOpaque())
+      {
+        return Convertible::Exact;
+      }
+
       switch (rb_type(value))
       {
         case RUBY_T_DATA:
@@ -1650,6 +1655,11 @@ namespace Rice::detail
 
     void* convert(VALUE value)
     {
+      if (this->arg_ && this->arg_->isOpaque())
+      {
+        return (void*)value;
+      }
+
       switch (rb_type(value))
       {
         case RUBY_T_DATA:
@@ -1657,7 +1667,7 @@ namespace Rice::detail
           // Since C++ is not telling us type information, we need to extract it
           // from the Ruby object.
           const rb_data_type_t* rb_type = RTYPEDDATA_TYPE(value);
-          return detail::unwrap<void>(value, (rb_data_type_t*)rb_type, this->arg_ && this->arg_->isTransfer());
+          return detail::unwrap<void>(value, (rb_data_type_t*)rb_type, this->arg_ && this->arg_->isOwner());
           break;
         }
         case RUBY_T_STRING:
@@ -1673,8 +1683,10 @@ namespace Rice::detail
           break;
         }
         default:
+        {
           throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
             detail::protect(rb_obj_classname, value), "pointer");
+        }
       }
     }
   private:

--- a/rice/detail/to_ruby.ipp
+++ b/rice/detail/to_ruby.ipp
@@ -7,27 +7,51 @@ namespace Rice
     class To_Ruby<void>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const void*)
       {
         throw std::runtime_error("Converting from void pointer is not implemented");
         return Qnil;
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<std::nullptr_t>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(std::nullptr_t const)
       {
         return Qnil;
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<short>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const short& native)
       {
 #ifdef rb_int2num_inline
@@ -36,12 +60,21 @@ namespace Rice
         return RB_INT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<short&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const short& native)
       {
 #ifdef rb_int2num_inline
@@ -50,12 +83,21 @@ namespace Rice
         return RB_INT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<int>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const int& native)
       {
 #ifdef rb_int2num_inline
@@ -73,12 +115,21 @@ namespace Rice
         return RB_INT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<int&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const int& native)
       {
 #ifdef rb_int2num_inline
@@ -87,52 +138,97 @@ namespace Rice
         return RB_INT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<long>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const long& native)
       {
         return protect(rb_long2num_inline, native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<long&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const long& native)
       {
         return protect(rb_long2num_inline, native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<long long>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const long long& native)
       {
         return protect(rb_ll2inum, native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<long long&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const long long& native)
       {
         return protect(rb_ll2inum, native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<unsigned short>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const unsigned short& native)
       {
 #ifdef rb_int2num_inline
@@ -141,12 +237,21 @@ namespace Rice
         return RB_UINT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<unsigned short&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const unsigned short& native)
       {
 #ifdef rb_int2num_inline
@@ -155,12 +260,21 @@ namespace Rice
         return RB_UINT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<unsigned int>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const unsigned int& native)
       {
 #ifdef rb_int2num_inline
@@ -169,12 +283,21 @@ namespace Rice
         return RB_UINT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<unsigned int&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const unsigned int& native)
       {
 #ifdef rb_int2num_inline
@@ -183,6 +306,9 @@ namespace Rice
         return RB_UINT2NUM(native);
 #endif
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
@@ -191,13 +317,13 @@ namespace Rice
     public:
       To_Ruby() = default;
 
-      explicit To_Ruby(Return* returnInfo) : returnInfo_(returnInfo)
+      explicit To_Ruby(Arg* arg) : arg_(arg)
       {
       }
 
       VALUE convert(const unsigned long& native)
       {
-        if (this->returnInfo_ && this->returnInfo_->isValue())
+        if (this->arg_ && this->arg_->isValue())
         {
           return native;
         }
@@ -208,7 +334,7 @@ namespace Rice
       }
 
     private:
-      Return* returnInfo_ = nullptr;
+      Arg* arg_ = nullptr;
     };
 
     template<>
@@ -217,13 +343,13 @@ namespace Rice
     public:
       To_Ruby() = default;
 
-      explicit To_Ruby(Return* returnInfo) : returnInfo_(returnInfo)
+      explicit To_Ruby(Arg* arg) : arg_(arg)
       {
       }
 
       VALUE convert(const unsigned long& native)
       {
-        if (this->returnInfo_ && this->returnInfo_->isValue())
+        if (this->arg_ && this->arg_->isValue())
         {
           return native;
         }
@@ -234,7 +360,7 @@ namespace Rice
       }
 
     private:
-      Return* returnInfo_ = nullptr;
+      Arg* arg_ = nullptr;
     };
 
     template<>
@@ -243,13 +369,13 @@ namespace Rice
     public:
       To_Ruby() = default;
 
-      explicit To_Ruby(Return* returnInfo) : returnInfo_(returnInfo)
+      explicit To_Ruby(Arg* arg) : arg_(arg)
       {
       }
 
       VALUE convert(const unsigned long long& native)
       {
-        if (this->returnInfo_ && this->returnInfo_->isValue())
+        if (this->arg_ && this->arg_->isValue())
         {
           return native;
         }
@@ -261,7 +387,7 @@ namespace Rice
 
       VALUE convert(const volatile unsigned long long& native)
       {
-        if (this->returnInfo_ && this->returnInfo_->isValue())
+        if (this->arg_ && this->arg_->isValue())
         {
           return native;
         }
@@ -271,7 +397,7 @@ namespace Rice
         }
       }
     private:
-      Return* returnInfo_ = nullptr;
+      Arg* arg_ = nullptr;
     };
 
     template<>
@@ -280,13 +406,13 @@ namespace Rice
     public:
       To_Ruby() = default;
 
-      explicit To_Ruby(Return* returnInfo) : returnInfo_(returnInfo)
+      explicit To_Ruby(Arg* arg) : arg_(arg)
       {
       }
 
       VALUE convert(const unsigned long long& native)
       {
-        if (this->returnInfo_ && this->returnInfo_->isValue())
+        if (this->arg_ && this->arg_->isValue())
         {
           return native;
         }
@@ -297,87 +423,159 @@ namespace Rice
       }
 
     private:
-      Return* returnInfo_ = nullptr;
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<float>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const float& native)
       {
         return protect(rb_float_new, (double)native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<float&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const float& native)
       {
         return protect(rb_float_new, (double)native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<double>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const double& native)
       {
         return protect(rb_float_new, native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<double&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const double& native)
       {
         return protect(rb_float_new, native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<bool>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const bool& native)
       {
         return native ? Qtrue : Qfalse;
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<bool&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const bool& native)
       {
         return native ? Qtrue : Qfalse;
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<char>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const char& native)
       {
         return To_Ruby<int>().convert(native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<char&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const char& native)
       {
         return To_Ruby<int>().convert(native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
@@ -386,7 +584,7 @@ namespace Rice
     public:
       To_Ruby() = default;
 
-      explicit To_Ruby(Return* returnInfo) : returnInfo_(returnInfo)
+      explicit To_Ruby(Arg* arg) : arg_(arg)
       {
       }
 
@@ -405,7 +603,7 @@ namespace Rice
           delete[] symbol;
           return protect(rb_id2sym, id);
         }
-        else if (this->returnInfo_ && this->returnInfo_->isOwner())
+        else if (this->arg_ && this->arg_->isOwner())
         {
           // This copies the buffer but does not free it. So Ruby is not really
           // taking ownership of it. But there isn't a Ruby API for creating a string
@@ -421,13 +619,19 @@ namespace Rice
       }
 
     private:
-      Return* returnInfo_ = nullptr;
+      Arg* arg_ = nullptr;
     };
 
     template<int N>
     class To_Ruby<char[N]>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const char buffer[])
       {
         if (N > 0 && buffer[0] == ':')
@@ -445,46 +649,124 @@ namespace Rice
           return protect(rb_usascii_str_new_static, buffer, size);
         }
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<unsigned char>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const unsigned char& native)
       {
         return To_Ruby<unsigned int>().convert(native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<unsigned char&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const unsigned char& native)
       {
         return To_Ruby<unsigned int>().convert(native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<signed char>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const signed char& native)
       {
         return To_Ruby<signed int>().convert(native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
     };
 
     template<>
     class To_Ruby<signed char&>
     {
     public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
       VALUE convert(const signed char& native)
       {
         return To_Ruby<signed int>().convert(native);
       }
+
+    private:
+      Arg* arg_ = nullptr;
+    };
+
+    template <>
+    class To_Ruby<void*>
+    {
+    public:
+      To_Ruby() = default;
+
+      explicit To_Ruby(Arg* arg) : arg_(arg)
+      {
+      }
+
+      VALUE convert(void* data)
+      {
+        if (this->arg_ && this->arg_->isOpaque())
+        {
+          return VALUE(data);
+        }
+        else if (data)
+        {
+          // Note that T could be a pointer or reference to a base class while data is in fact a
+          // child class. Lookup the correct type so we return an instance of the correct Ruby class
+          std::pair<VALUE, rb_data_type_t*> rubyTypeInfo = detail::Registries::instance.types.figureType(data);
+          bool isOwner = this->arg_ && this->arg_->isOwner();
+          return detail::wrap(rubyTypeInfo.first, rubyTypeInfo.second, data, isOwner);
+        }
+        else
+        {
+          return Qnil;
+        }
+      }
+
+      VALUE convert(const void* data)
+      {
+        return convert((void*)data);
+      }
+
+    private:
+      Arg* arg_ = nullptr;
     };
   }
 }

--- a/rice/global_function.ipp
+++ b/rice/global_function.ipp
@@ -2,5 +2,5 @@
 template<typename Function_T, typename...Arg_Ts>
 void Rice::define_global_function(char const * name, Function_T&& func, Arg_Ts const& ...args)
 {
-  Module(rb_mKernel).define_module_function(name, std::forward<Function_T>(func), args...);
+    Module(rb_mKernel).define_module_function(name, std::forward<Function_T>(func), args...);
 }

--- a/rice/rice.hpp
+++ b/rice/rice.hpp
@@ -49,7 +49,17 @@
 #include "detail/Wrapper.hpp"
 #include "detail/to_ruby.hpp"
 #include "detail/from_ruby.hpp"
+#include "detail/Native.hpp"
 
+// Registries
+#include "detail/TypeRegistry.hpp"
+#include "detail/InstanceRegistry.hpp"
+#include "detail/DefaultHandler.hpp"
+#include "detail/HandlerRegistry.hpp"
+#include "detail/NativeRegistry.hpp"
+#include "detail/Registries.hpp"
+
+// To / From Ruby
 #include "Arg.hpp"
 #include "Arg.ipp"
 #include "Return.hpp"
@@ -59,20 +69,11 @@
 #include "detail/Proc.hpp"
 
 // Registries
-#include "detail/TypeRegistry.hpp"
 #include "detail/TypeRegistry.ipp"
-#include "detail/InstanceRegistry.hpp"
 #include "detail/InstanceRegistry.ipp"
-
-#include "detail/DefaultHandler.hpp"
 #include "detail/DefaultHandler.ipp"
-#include "detail/HandlerRegistry.hpp"
 #include "detail/HandlerRegistry.ipp"
-
-#include "detail/Native.hpp"
-#include "detail/NativeRegistry.hpp"
 #include "detail/NativeRegistry.ipp"
-#include "detail/Registries.hpp"
 #include "detail/Registries.ipp"
 
 #include "detail/Type.ipp"
@@ -128,6 +129,8 @@
 #include "detail/default_allocation_func.ipp"
 #include "Constructor.hpp"
 #include "Constructor.ipp"
+#include "Callback.hpp"
+#include "Callback.ipp"
 #include "Data_Object.hpp"
 #include "Data_Object.ipp"
 #include "Enum.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,6 +81,7 @@ add_executable(unittest
                "test_Stl_Vector.cpp")
 
 target_include_directories(unittest PRIVATE ..)
+#target_compile_definitions(unittest PRIVATE -DHAVE_LIBFFI)
 target_include_directories(unittest PRIVATE ${Ruby_INCLUDE_DIR} ${Ruby_CONFIG_INCLUDE_DIR})
 target_include_directories(unittest PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(unittest ${Ruby_LIBRARY})
+target_link_libraries(unittest ${Ruby_LIBRARY} ffi)

--- a/test/test_Ownership.cpp
+++ b/test/test_Ownership.cpp
@@ -132,7 +132,7 @@ SETUP(Ownership)
     define_method("value", &Factory::value).
     define_method("move_value", &Factory::moveValue).
     define_method("transfer_pointer_to_ruby", &Factory::transferPointerToRuby, Return().takeOwnership()).
-    define_method("transfer_pointer_to_cpp", &Factory::transferPointerToCpp, Arg("myClass").transferOwnership()).
+    define_method("transfer_pointer_to_cpp", &Factory::transferPointerToCpp, Arg("myClass").takeOwnership()).
     define_method("keep_pointer", &Factory::keepPointer).
     define_method("copy_reference", &Factory::keepReference, Return().takeOwnership()).
     define_method("keep_reference", &Factory::keepReference);

--- a/test/test_Stl_SmartPointer.cpp
+++ b/test/test_Stl_SmartPointer.cpp
@@ -172,11 +172,11 @@ SETUP(SmartPointer)
     define_method("take_ownership", &Sink::takeOwnership).
     define_method("share_ownership", &Sink::shareOwnership).
     define_method<int(Sink::*)(std::unique_ptr<MyClass>&, MyClass*)>("update_pointer", &Sink::updatePointer, 
-      Arg("ptr"), Arg("myClass").transferOwnership()).
+      Arg("ptr"), Arg("myClass").takeOwnership()).
     define_method<int(Sink::*)(std::shared_ptr<MyClass>&, MyClass*)>("update_pointer", &Sink::updatePointer,
-      Arg("ptr"), Arg("myClass").transferOwnership()).
+      Arg("ptr"), Arg("myClass").takeOwnership()).
     define_method("make_void_shared", &Sink::makeVoidShared,
-      Arg("myClass").transferOwnership()).
+      Arg("myClass").takeOwnership()).
     define_method<int(Sink::*)(std::shared_ptr<void>&)>("handle_void", &Sink::handleVoid);
 
   // Needed for shared_ptr<void>
@@ -200,7 +200,7 @@ TEARDOWN(SmartPointer)
 #endif
 }
 
-TESTCASE(TransferOwnership)
+TESTCASE(takeOwnership)
 {
   MyClass::reset();
   Factory::reset();


### PR DESCRIPTION
Align Return and Arg to make calling Ruby from C (callbacks) and Ruby to C consistent. Add opaque argument to allow Ruby to pass data through C callbacks that support user data via void*