### PR TITLE
Fix test issues on Ruby 3.4

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: ['3.1', '3.2', '3.3']
+        ruby: ['3.1', '3.2', '3.3', '3.4']
         exclude:
           # There's something wrong with this setup in GHA such that
           # it gets weird linking errors, however I'm unable to reproduce

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,5 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Configure
       run: rake headers
-    - name: Build
-      run: rake build
-    - name: Test
+    - name: Build and test
       run: rake test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
         ruby: ['3.1', '3.2', '3.3', '3.4']
         exclude:
           # There's something wrong with this setup in GHA such that

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,13 @@ task :clean do
   binaries.each do |asset|
     dir = File.dirname(asset)
     cd dir do
-      run_command(MAKE, "clean")
+      begin
+        run_command(MAKE, "clean")
+      rescue
+        # If clean crashes, that's probably means there's no Makefile
+        # which is fine. That means this is a fresh checkout or the directory
+        # already otherwise got cleaned.
+      end
     end
   end
 end

--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -8,6 +8,13 @@ void embed_ruby()
   if (!initialized__)
   {
     RUBY_INIT_STACK;
+
+    int argc = 0;
+    char* argv = nullptr;
+    char** pArgv = &argv;
+
+    ruby_sysinit(&argc, &pArgv);
+
     ruby_init();
     ruby_init_loadpath();
 

--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -14,6 +14,7 @@ void embed_ruby()
     ruby_sysinit(&argc, &pArgv);
     ruby_init();
     ruby_init_loadpath();
+    rb_gc_disable();
 
 #if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 1
     // Force the prelude / builtins

--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -7,14 +7,9 @@ void embed_ruby()
 
   if (!initialized__)
   {
-    int argc = 0;
-    char* argv = nullptr;
-    char** pArgv = &argv;
-
-    ruby_sysinit(&argc, &pArgv);
+    RUBY_INIT_STACK;
     ruby_init();
     ruby_init_loadpath();
-    rb_gc_disable();
 
 #if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 1
     // Force the prelude / builtins

--- a/test/test_Keep_Alive.cpp
+++ b/test/test_Keep_Alive.cpp
@@ -160,7 +160,7 @@ TESTCASE(test_return)
   Module m = define_module("TestingModule");
 
   Object column = getColumn(m, 3);
-  rb_gc_start();
+  //rb_gc_start();
   String name = column.call("name");
   ASSERT_EQUAL("column_3", name.c_str());
 }

--- a/test/test_Keep_Alive.cpp
+++ b/test/test_Keep_Alive.cpp
@@ -160,7 +160,7 @@ TESTCASE(test_return)
   Module m = define_module("TestingModule");
 
   Object column = getColumn(m, 3);
-  //rb_gc_start();
+  rb_gc_start();
   String name = column.call("name");
   ASSERT_EQUAL("column_3", name.c_str());
 }

--- a/test/test_Overloads.cpp
+++ b/test/test_Overloads.cpp
@@ -513,13 +513,21 @@ TESTCASE(int_conversion_4)
             my_class.run(value))";
 
 #ifdef _WIN32
-  const char* expected = "bignum too big to convert into `long'";
+
+#if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 4
+  const char* expected = "bignum too big to convert into 'long'";
 #else
+  const char* expected = "bignum too big to convert into `long'";
+#endif
+
+#else
+
 #if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 4
   const char* expected = "integer 4398046511104 too big to convert to 'short'";
 #else
   const char* expected = "integer 4398046511104 too big to convert to `short'";
 #endif
+
 #endif
 
   ASSERT_EXCEPTION_CHECK(

--- a/test/test_Overloads.cpp
+++ b/test/test_Overloads.cpp
@@ -2,6 +2,7 @@
 #include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
+#include <ruby/version.h>
 
 using namespace Rice;
 
@@ -514,7 +515,11 @@ TESTCASE(int_conversion_4)
 #ifdef _WIN32
   const char* expected = "bignum too big to convert into `long'";
 #else
+#if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 4
+  const char* expected = "integer 4398046511104 too big to convert to 'short'";
+#else
   const char* expected = "integer 4398046511104 too big to convert to `short'";
+#endif
 #endif
 
   ASSERT_EXCEPTION_CHECK(

--- a/test/test_Stl_Map.cpp
+++ b/test/test_Stl_Map.cpp
@@ -5,6 +5,7 @@
 #include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
+#include <ruby/version.h>
 
 using namespace Rice;
 
@@ -257,7 +258,11 @@ TESTCASE(Iterate)
   ASSERT_EQUAL(3u, result.size());
 
   std::string result_string = result.to_s().str();
+#if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 4
+  ASSERT_EQUAL("{\"five\" => 10, \"seven\" => 14, \"six\" => 12}", result_string);
+#else
   ASSERT_EQUAL("{\"five\"=>10, \"seven\"=>14, \"six\"=>12}", result_string);
+#endif
 }
 
 TESTCASE(ToEnum)
@@ -280,7 +285,12 @@ TESTCASE(ToEnum)
   ASSERT_EQUAL(3u, result.size());
 
   std::string result_string = result.to_s().str();
+
+#if RUBY_API_VERSION_MAJOR == 3 && RUBY_API_VERSION_MINOR >= 4
+  ASSERT_EQUAL("{\"five\" => 10, \"seven\" => 14, \"six\" => 12}", result_string);
+#else
   ASSERT_EQUAL("{\"five\"=>10, \"seven\"=>14, \"six\"=>12}", result_string);
+#endif
 }
 
 TESTCASE(ToEnumSize)

--- a/test/test_Tracking.cpp
+++ b/test/test_Tracking.cpp
@@ -225,11 +225,11 @@ TESTCASE(RubyObjectGced)
   {
     // Track the C++ object returned by keepPointer
     Data_Object<MyClass> my_class1 = factory.call("keep_pointer");
-    rb_gc_start();
+    //rb_gc_start();
   }
 
   // Make my_class1 invalid
-  rb_gc_start();
+  //rb_gc_start();
 
   // Get the object again - this should *not* return the previous value
   Data_Object<MyClass> my_class2 = factory.call("keep_pointer");

--- a/test/test_Tracking.cpp
+++ b/test/test_Tracking.cpp
@@ -225,11 +225,11 @@ TESTCASE(RubyObjectGced)
   {
     // Track the C++ object returned by keepPointer
     Data_Object<MyClass> my_class1 = factory.call("keep_pointer");
-    //rb_gc_start();
+    rb_gc_start();
   }
 
   // Make my_class1 invalid
-  //rb_gc_start();
+  rb_gc_start();
 
   // Get the object again - this should *not* return the previous value
   Data_Object<MyClass> my_class2 = factory.call("keep_pointer");


### PR DESCRIPTION
This PR fixes up the test problems we were seeing under Ruby 3.4. The main issue was the lack of `RUBY_INIT_STACK` which has existed for a long time but looks like for Ruby 3.4 is now definitely needed. The lack of this call in `embed_ruby.cpp` was leading to very strange and inconsistent GC-related errors.