### PR TITLE
Fix FFI Closures on Mac

### DIFF
--- a/lib/mkmf-rice.rb
+++ b/lib/mkmf-rice.rb
@@ -66,7 +66,7 @@ def system_libffi_usable?
   libffi_ok
 end
 
-# Check for libffi to support C style callacks. MacOS for now is crashing so disable
-if system_libffi_usable? && !IS_DARWIN
+# Check for libffi to support C style callacks.
+if system_libffi_usable?
   $CPPFLAGS += " -DHAVE_LIBFFI"
 end

--- a/rice/detail/NativeCallbackFFI.ipp
+++ b/rice/detail/NativeCallbackFFI.ipp
@@ -117,8 +117,8 @@ namespace Rice::detail
     }
 
     // Create FFI closure
-    this->closure_ = (ffi_closure *)ffi_closure_alloc(sizeof(ffi_closure), (void**)(&this->callback_));
-    ffi_status status = ffi_prep_closure_loc(this->closure_, &cif_, ffiCallback, (void*)this, nullptr);
+    this->closure_ = (ffi_closure *)ffi_closure_alloc(sizeof(ffi_closure) + sizeof(void*), (void**)(&this->callback_));
+    ffi_status status = ffi_prep_closure_loc(this->closure_, &cif_, ffiCallback, (void*)this, (void*)this->callback_);
   }
 
   template<typename Return_T, typename ...Arg_Ts>


### PR DESCRIPTION
The code_loc parameter of ffi_prep_closure_loc is important for macOS and similar systems that have more explicit control and restrictions on writeable vs executable memory.

Took a very close read of the [documentation](https://www.chiark.greenend.org.uk/doc/libffi-dev/html/The-Closure-API.html) to figure out how this was supposed to be used.