### PR TITLE
Fix is_convertible example

### DIFF
--- a/doc/bindings/type_conversions.rst
+++ b/doc/bindings/type_conversions.rst
@@ -106,7 +106,7 @@ Last, if we want to convert a Ruby array to a  ``std::deque<int>``, then we need
     class From_Ruby<std::deque<int>>
     {
     public:
-      Convertible convertible(VALUE value)
+      Convertible is_convertible(VALUE value)
       {
         switch (rb_type(value))
         {


### PR DESCRIPTION
`convertible` -> `is_convertible`