### PR TITLE
Include `Rice::VERSION` in published gem

### DIFF
--- a/rice.gemspec
+++ b/rice.gemspec
@@ -49,7 +49,8 @@ Ruby extensions with C++ easier.
 
     # Ruby files
     'lib/mkmf-rice.rb',
-    'lib/version.rb',
+    'lib/rice.rb',
+    'lib/rice/version.rb',
 
     # Samples
     'sample/enum/extconf.rb',


### PR DESCRIPTION
`require "rice"` and `require "rice/version"` raise a `LoadError` since the files aren't included in the gemspec.

```sh
gem unpack rice
find rice-4.5.0 | grep version # no file found
```