### PR TITLE
Add Rice version macros

### DIFF
--- a/lib/mkmf-rice.rb
+++ b/lib/mkmf-rice.rb
@@ -1,4 +1,8 @@
 require 'mkmf'
+require 'rice/version'
+
+major, minor, patch = Rice::VERSION.split(".")
+$CXXFLAGS += " -DRICE_VERSION_MAJOR=#{major} -DRICE_VERSION_MINOR=#{minor} -DRICE_VERSION_PATCH=#{patch}"
 
 IS_MSWIN = /mswin/ =~ RUBY_PLATFORM
 IS_MINGW = /mingw/ =~ RUBY_PLATFORM


### PR DESCRIPTION
This should make it easier for projects to support multiple versions of Rice.

```cpp
#if RICE_VERSION_MAJOR > 4 || (RICE_VERSION_MAJOR == 4 && RICE_VERSION_MINOR >= 5)
Convertible is_convertible(VALUE value) { ... }
#endif
```

or

```cpp
#if RICE_VERSION_MAJOR > 4 || (RICE_VERSION_MAJOR == 4 && RICE_VERSION_MINOR >= 5)
Rice::detail::Registries::instance.handlers.set(...)
#else
register_handler<MyError>(...);
#endif
```