### PR TITLE
Move `for_each_tuple` to Rice namespace

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -386,14 +386,17 @@ namespace Rice::detail
 
 // =========   TupleIterator.hpp   =========
 
-// See https://www.cppstories.com/2022/tuple-iteration-apply/
-template <typename Tuple_T, typename Function_T>
-void for_each_tuple(Tuple_T&& tuple, Function_T&& callable)
+namespace Rice::detail
 {
-    std::apply([&callable](auto&& ...args)
-      {
-        (callable(std::forward<decltype(args)>(args)), ...);
-      }, std::forward<Tuple_T>(tuple));
+  // See https://www.cppstories.com/2022/tuple-iteration-apply/
+  template <typename Tuple_T, typename Function_T>
+  void for_each_tuple(Tuple_T&& tuple, Function_T&& callable)
+  {
+      std::apply([&callable](auto&& ...args)
+        {
+          (callable(std::forward<decltype(args)>(args)), ...);
+        }, std::forward<Tuple_T>(tuple));
+  }
 }
 
 

--- a/rice/detail/TupleIterator.hpp
+++ b/rice/detail/TupleIterator.hpp
@@ -1,14 +1,17 @@
 #ifndef Rice__stl__tuple_iterator__hpp_
 #define Rice__stl__tuple_iterator__hpp_
 
-// See https://www.cppstories.com/2022/tuple-iteration-apply/
-template <typename Tuple_T, typename Function_T>
-void for_each_tuple(Tuple_T&& tuple, Function_T&& callable)
+namespace Rice::detail
 {
-    std::apply([&callable](auto&& ...args)
-      {
-        (callable(std::forward<decltype(args)>(args)), ...);
-      }, std::forward<Tuple_T>(tuple));
+  // See https://www.cppstories.com/2022/tuple-iteration-apply/
+  template <typename Tuple_T, typename Function_T>
+  void for_each_tuple(Tuple_T&& tuple, Function_T&& callable)
+  {
+      std::apply([&callable](auto&& ...args)
+        {
+          (callable(std::forward<decltype(args)>(args)), ...);
+        }, std::forward<Tuple_T>(tuple));
+  }
 }
 
 #endif // Rice__stl__tuple_iterator__hpp_


### PR DESCRIPTION
It's currently in the global namespace.

[Diff without whitespace changes](https://github.com/ruby-rice/rice/pull/253/files?diff=unified&w=1)