### PR TITLE
Use Std for Autogenerated Stl Classes Namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Update is_convertible documentation
 * Fix missing version.rb file in gemspec
 * Add C++ preprocessor defines for Rice version
+* Moved auto-generated C++ STL classes (std::vector, std::map, etc) from the module Rice::Std module to just Std
 
 ## 4.5 (2025-02-09)
 Rice 4.5 is a major release that adds significant new functionality, including:

--- a/doc/stl/exception.rst
+++ b/doc/stl/exception.rst
@@ -20,7 +20,7 @@ Thus Rice provides access to creating new C++ exception instances:
 
 .. code-block:: cpp
 
-   exception = Rice::Std::Exception.new
+   exception = Std::Exception.new
 
 Note currently only supports creating instances of ``std::exception`` and none of its subtypes.
 

--- a/doc/stl/stl.rst
+++ b/doc/stl/stl.rst
@@ -44,11 +44,11 @@ Many STL classes are templates, and thus must be instantiated with concrete type
 
 Rice makes it easy to manually create Ruby classes for instantiated STL templates. The way to do this varies per STL type, but follows a simple naming scheme - ``define_pair``, ``define_vector``, etc. Please refer to the documentation for each supported STL type.
 
-Rice can also automatically generate Ruby classes. These Ruby classes are added to the ``Rice::Std`` module. Automatic classes work well in cases where Ruby code is accessing, or modifying, wrapped objects created in C++.
+Rice can also automatically generate Ruby classes. These Ruby classes are added to the ``Std`` module. Automatic classes work well in cases where Ruby code is accessing, or modifying, wrapped objects created in C++.
 
 Sometimes Ruby also needs to create new instances of these classes. With manually defined class names, this is easy to do. With generated class names you need to understand how Rice creates class names.
 
-Starting in version 4.5, Rice makes use of three unicode characters to create class names that "look" like their C++ counterparts. For example, the type ``std::pair<std::string, double>`` becomes ``Rice::Std::Pair≺string≺char≻‚ double≻``.  Or assume there is a vector containing a custom class ``MyNamespace::MyClass``. Then generated name would be ``Rice::Std::Vector≺MyNamespace꞉꞉MyClass≻``.
+Starting in version 4.5, Rice makes use of unicode characters to create class names that "look" like their C++ counterparts. For example, the type ``std::pair<std::string, double>`` becomes ``Std::Pair≺string≺char≻‚ double≻``.  Or assume there is a vector containing a custom class ``MyNamespace::MyClass``. Then generated name would be ``Std::Vector≺MyNamespace꞉꞉MyClass≻``.
 
 The unicode characters are:
 
@@ -63,18 +63,18 @@ The unicode characters are:
 +-------------+-------------+-----------------------------+
 | ,           | U+066C      | Arabic Thousands Separator  |
 +-------------+-------------+-----------------------------+
-|             | U+u00A0     | Non breaking Space          |
+|          | U+u00A0     | Non breaking Space          |
 +-------------+-------------+-----------------------------+
 
 To use this class in Ruby:
 
 .. code-block:: ruby
 
-    pair = Rice::Std::Pair≺string≺char≻‚ double≻.new
+    pair = Std::Pair≺string≺char≻‚ double≻.new
 
 Note manual class names can be defined *after* auto generated class names. Rice only registers one class with Ruby, but it has two constants pointing at it. For example if you call ``define_pair<std::pair<std::string, double>>(StringDoublePair)`` after the pair has been registered, in Ruby you will have two constants pointing to the class:
 
 .. code-block:: ruby
 
-    Rice::Std::Pair≺string≺char≻‚ double≻
+    Std::Pair≺string≺char≻‚ double≻
     Object::StringDoublePair

--- a/rice/stl/exception.ipp
+++ b/rice/stl/exception.ipp
@@ -8,8 +8,7 @@ namespace Rice::stl
 
   inline void define_stl_exception()
   {
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
+    Module rb_mStd = define_module("Std");
     rb_cStlException = define_class_under<std::exception>(rb_mStd, "Exception", rb_eStandardError).
                         define_constructor(Constructor<std::exception>()).
                         define_method("message", &std::exception::what);

--- a/rice/stl/exception_ptr.ipp
+++ b/rice/stl/exception_ptr.ipp
@@ -4,9 +4,7 @@ namespace Rice::stl
 {
   inline Data_Type<std::exception_ptr> define_exception_ptr()
   {
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
-
+    Module rb_mStd = define_module("Std");
     return define_class_under<std::exception_ptr>(rb_mStd, "ExceptionPtr");
   }
 }

--- a/rice/stl/map.ipp
+++ b/rice/stl/map.ipp
@@ -281,10 +281,9 @@ namespace Rice
   template<typename T>
   Data_Type<T> define_map_auto()
   {
+    Module rb_mStd = define_module("Std");
     std::string name = detail::typeName(typeid(T));
     std::string klassName = detail::makeClassName(name);
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
     return define_map_under<T>(rb_mStd, klassName);
   }
    

--- a/rice/stl/pair.ipp
+++ b/rice/stl/pair.ipp
@@ -149,10 +149,9 @@ namespace Rice
   template<typename T>
   Data_Type<T> define_pair_auto()
   {
+    Module rb_mStd = define_module("Std");
     std::string name = detail::typeName(typeid(T));
     std::string klassName = detail::makeClassName(name);
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
     return define_pair_under<T>(rb_mStd, klassName);
   }
    

--- a/rice/stl/type_index.ipp
+++ b/rice/stl/type_index.ipp
@@ -4,9 +4,7 @@ namespace Rice::stl
 {
   inline Data_Type<std::type_index> define_type_index()
   {
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
-
+    Module rb_mStd = define_module("Std");
     return define_class_under<std::type_index>(rb_mStd, "TypeIndex").
       define_constructor(Constructor<std::type_index, const std::type_info&>()).
       define_method("hash_code", &std::type_index::hash_code).

--- a/rice/stl/type_info.ipp
+++ b/rice/stl/type_info.ipp
@@ -4,9 +4,7 @@ namespace Rice::stl
 {
   inline Data_Type<std::type_info> define_type_info()
   {
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
-
+    Module rb_mStd = define_module("Std");
     return define_class_under<std::type_info>(rb_mStd, "TypeInfo").
       define_method("hash_code", &std::type_info::hash_code).
       define_method("name", &std::type_info::name);

--- a/rice/stl/unordered_map.ipp
+++ b/rice/stl/unordered_map.ipp
@@ -278,10 +278,9 @@ namespace Rice
   template<typename T>
   Data_Type<T> define_unordered_map_auto()
   {
+    Module rb_mStd = define_module("Std");
     std::string name = detail::typeName(typeid(T));
     std::string klassName = detail::makeClassName(name);
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
     return define_unordered_map_under<T>(rb_mStd, klassName);
   }
    

--- a/rice/stl/vector.ipp
+++ b/rice/stl/vector.ipp
@@ -395,10 +395,9 @@ namespace Rice
   template<typename T>
   Data_Type<T> define_vector_auto()
   {
+    Module rb_mStd = define_module("Std");
     std::string name = detail::typeName(typeid(T));
     std::string klassName = detail::makeClassName(name);
-    Module rb_mRice = define_module("Rice");
-    Module rb_mStd = define_module_under(rb_mRice, "Std");
     return define_vector_under<T>(rb_mStd, klassName);
   }
    

--- a/test/test_Stl_Map.cpp
+++ b/test/test_Stl_Map.cpp
@@ -447,7 +447,7 @@ TESTCASE(AutoRegisterReturn)
 
   Module m = define_module("Testing");
   Object map = m.module_eval("return_complex_map");
-  ASSERT_EQUAL(u8"Rice::Std::Map≺string≺char≻‚ complex≺double≻≻",
+  ASSERT_EQUAL(u8"Std::Map≺string≺char≻‚ complex≺double≻≻",
                map.class_name().str());
 
   std::string code = R"(map = return_complex_map
@@ -474,7 +474,7 @@ TESTCASE(AutoRegisterParameter)
 {
   define_global_function("pass_complex_map", &passComplexMap);
 
-  std::string code = u8R"(map = Rice::Std::Map≺string≺char≻‚ complex≺double≻≻.new
+  std::string code = u8R"(map = Std::Map≺string≺char≻‚ complex≺double≻≻.new
                           map["four"] = Complex(4.0, 4.0)
                           map["five"] = Complex(5.0, 5.0)
                           pass_complex_map(map))";
@@ -483,7 +483,7 @@ TESTCASE(AutoRegisterParameter)
   Object map = m.module_eval(code);
 
   Object result = map.call("size");
-  ASSERT_EQUAL(u8"Rice::Std::Map≺string≺char≻‚ complex≺double≻≻",
+  ASSERT_EQUAL(u8"Std::Map≺string≺char≻‚ complex≺double≻≻",
                map.class_name().str());
   ASSERT_EQUAL(2, detail::From_Ruby<int32_t>().convert(result));
 

--- a/test/test_Stl_Pair.cpp
+++ b/test/test_Stl_Pair.cpp
@@ -107,7 +107,7 @@ TESTCASE(AutoRegister)
 
   Object pair = someClass.call("pair");
   String name = pair.class_name();
-  ASSERT_EQUAL(u8"Rice::Std::Pair≺string≺char≻‚ double≻", detail::From_Ruby<std::string>().convert(name));
+  ASSERT_EQUAL(u8"Std::Pair≺string≺char≻‚ double≻", detail::From_Ruby<std::string>().convert(name));
 
   Class pairKlass1 = pair.class_of();
   Class pairKlass2 = Data_Type<std::pair<std::string, double>>::klass();

--- a/test/test_Stl_Type.cpp
+++ b/test/test_Stl_Type.cpp
@@ -97,7 +97,7 @@ TESTCASE(TypeIndexCreate)
 
   std::string code = R"(int = 5
                         type_info = get_type_info(5)
-                        Rice::Std::TypeIndex.new(type_info))";
+                        Std::TypeIndex.new(type_info))";
 
 #ifdef _MSC_VER
   const char* expected = "int";

--- a/test/test_Stl_Unordered_Map.cpp
+++ b/test/test_Stl_Unordered_Map.cpp
@@ -443,7 +443,7 @@ TESTCASE(AutoRegisterReturn)
 
   Module m = define_module("Testing");
   Object unordered_map = m.module_eval("return_complex_unordered_map");
-  ASSERT_EQUAL(u8"Rice::Std::UnorderedMap≺string≺char≻‚ complex≺double≻≻",
+  ASSERT_EQUAL(u8"Std::UnorderedMap≺string≺char≻‚ complex≺double≻≻",
                unordered_map.class_name().str());
 
   std::string code = R"(unordered_map = return_complex_unordered_map
@@ -470,7 +470,7 @@ TESTCASE(AutoRegisterParameter)
 {
   define_global_function("pass_complex_unordered_map", &passComplexUnorderedMap);
 
-  std::string code = u8R"(unordered_map = Rice::Std::UnorderedMap≺string≺char≻‚ complex≺double≻≻.new
+  std::string code = u8R"(unordered_map = Std::UnorderedMap≺string≺char≻‚ complex≺double≻≻.new
                           unordered_map["four"] = Complex(4.0, 4.0)
                           unordered_map["five"] = Complex(5.0, 5.0)
                           pass_complex_unordered_map(unordered_map))";
@@ -479,7 +479,7 @@ TESTCASE(AutoRegisterParameter)
   Object unordered_map = m.module_eval(code);
 
   Object result = unordered_map.call("size");
-  ASSERT_EQUAL(u8"Rice::Std::UnorderedMap≺string≺char≻‚ complex≺double≻≻",
+  ASSERT_EQUAL(u8"Std::UnorderedMap≺string≺char≻‚ complex≺double≻≻",
                unordered_map.class_name().str());
   ASSERT_EQUAL(2, detail::From_Ruby<int32_t>().convert(result));
 

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -526,7 +526,7 @@ TESTCASE(AutoRegisterReturn)
 
   Module m = define_module("Testing");
   Object vec = m.module_eval("return_complex_vector");
-  ASSERT_EQUAL(u8"Rice::Std::Vector≺complex≺double≻≻", vec.class_name().str());
+  ASSERT_EQUAL(u8"Std::Vector≺complex≺double≻≻", vec.class_name().str());
 
   std::string code = R"(vector = return_complex_vector
                         complex = vector.last
@@ -552,7 +552,7 @@ TESTCASE(AutoRegisterParameter)
 {
   define_global_function("pass_complex_vector", &passComplexVector);
 
-  std::string code = u8R"(vector = Rice::Std::Vector≺complex≺double≻≻.new
+  std::string code = u8R"(vector = Std::Vector≺complex≺double≻≻.new
                           vector << Complex(4.0, 4.0)
                           vector << Complex(5.0, 5.0)
                           pass_complex_vector(vector))";
@@ -561,7 +561,7 @@ TESTCASE(AutoRegisterParameter)
   Object vec = m.module_eval(code);
 
   Object result = vec.call("size");
-  ASSERT_EQUAL(u8"Rice::Std::Vector≺complex≺double≻≻", vec.class_name().str());
+  ASSERT_EQUAL(u8"Std::Vector≺complex≺double≻≻", vec.class_name().str());
   ASSERT_EQUAL(2, detail::From_Ruby<int32_t>().convert(result));
 
   std::vector<std::complex<double>> complexes = detail::From_Ruby<std::vector<std::complex<double>>>().convert(vec);


### PR DESCRIPTION
Move autogenerated Stl classes from Rice::Std module to just Std:: which more naturally maps to C++ and is more consistent with wrapping other C++ libraries. For example, OpenCv classes are under the Cv namespace to match the C++ library.