### PR TITLE
Update define_* methods

### DIFF
--- a/doc/bindings/methods.rst
+++ b/doc/bindings/methods.rst
@@ -149,7 +149,7 @@ The above code works because the ``<<`` method returns the Array ``a``. You can 
 
 .. code-block:: cpp
 
-  define_vector<std::vector<int32_t>>().
+  define_vector<int32_t>().
   define_method("<<", [](std::vector<int32_t>& self, int32_t value) -> std::vector<int32_t>&  // <----- DON'T MISS THIS
   {
     self.push_back(value);

--- a/doc/stl/pair.rst
+++ b/doc/stl/pair.rst
@@ -6,7 +6,7 @@ std::pair
 
 Ruby does not have a concept of a pair. Therefore, Rice wraps ``std::pair`` which means that data is not copied between C++ and Ruby.
 
-Since ``std::pair`` is a template of two types, each ``std::pair`` instantiation is its own unique C++ class, and thus its own unique Ruby class. You may manually define pair classes or let Rice do it for you. To manually define a Ruby class, use either the ``define_pair`` or ``define_pair_under`` methods.
+Since ``std::pair`` is a template of two types, each ``std::pair`` instantiation is its own unique C++ class, and thus its own unique Ruby class. You may manually define pair classes or let Rice do it for you. To manually define a Ruby class, use either the ``define_pair`` method.
 
 Example:
 
@@ -17,7 +17,7 @@ Example:
      return std::make_pair(key, value);
   }
 
-  define_pair<std::pair<std::string, uint32_t>>("StringIntPair");
+  define_pair<std::string, uint32_t>("StringIntPair");
   define_global_function("make_string_int_pair", &makeStringIntPair);
 
 Once you have defined this Ruby class, you can create a new instance like this:

--- a/doc/stl/stl.rst
+++ b/doc/stl/stl.rst
@@ -72,7 +72,7 @@ To use this class in Ruby:
 
     pair = Std::Pair≺string‚ double≻.new
 
-Note manual class names can be defined *after* auto generated class names. Rice only registers one class with Ruby, but it has two constants pointing at it. For example if you call ``define_pair<std::pair<std::string, double>>(StringDoublePair)`` after the pair has been registered, in Ruby you will have two constants pointing to the class:
+Note manual class names can be defined *after* auto generated class names. Rice only registers one class with Ruby, but it has two constants pointing at it. For example if you call ``define_pair<std::string, double>(StringDoublePair)`` after the pair has been registered, in Ruby you will have two constants pointing to the class:
 
 .. code-block:: ruby
 

--- a/doc/stl/vector.rst
+++ b/doc/stl/vector.rst
@@ -22,7 +22,7 @@ Example:
      return std::vector {"one", "two", "three"};
   }
 
-  define_vector<std::vector<std::string>>("StringVector");
+  define_vector<std::string>("StringVector");
   define_global_function("make_string_vector", &makeStringVector);
 
 Once you have defined this Ruby class, you can create a new instance like this:
@@ -45,7 +45,7 @@ For example, assume this C++ code:
   {
   }
 
-  define_vector<std::vector<std::int>("IntVector");
+  define_vector<int>("IntVector");
   define_global_function("pass_vector", &passVector);
 
 One way to call it from Ruby is like this:

--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -1553,7 +1553,7 @@ namespace Rice
     String pack();
 
     // Join elements together
-    String join(std::string separator);
+    String join(char* separator);
 
   private:
     //! A helper class so array[index]=value can work.
@@ -2856,6 +2856,8 @@ namespace Rice::detail
   class RubyType
   {
   };
+
+  void define_ruby_types();
 }
 
 
@@ -2873,30 +2875,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { RUBY_T_NIL };
     static inline std::set<ruby_value_type> Narrowable = {  };
     static inline std::string packTemplate = "not supported";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<bool>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "bool*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -2910,30 +2888,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { RUBY_T_STRING };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_FIXNUM };
     static inline std::string packTemplate = CHAR_MIN < 0 ? "c*" : "C*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<char>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "char*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -2948,30 +2902,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { RUBY_T_STRING };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_FIXNUM };
     static inline std::string packTemplate = "c*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<signed char>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "signed char*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -2986,30 +2916,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { RUBY_T_STRING };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_FIXNUM };
     static inline std::string packTemplate = "C*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<unsigned char>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "unsigned char*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3023,30 +2929,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_FIXNUM };
     static inline std::string packTemplate = "s*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<short>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "short*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3060,30 +2942,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_FIXNUM };
     static inline std::string packTemplate = "S*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<unsigned short>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "unsigned short*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3099,30 +2957,6 @@ namespace Rice::detail
     // while int can go up to 4 billion
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_BIGNUM };
     static inline std::string packTemplate = "i*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<int>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = {"int*"};
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3138,30 +2972,6 @@ namespace Rice::detail
     // while int can go up to 4 billion
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_BIGNUM };
     static inline std::string packTemplate = "I*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<unsigned int>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "unsigned int*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3175,30 +2985,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_BIGNUM };
     static inline std::string packTemplate = "l_*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<long>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "long*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3212,30 +2998,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_BIGNUM};
     static inline std::string packTemplate = "L_*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<unsigned long>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "unsigned long*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3249,30 +3011,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { };
     static inline std::set<ruby_value_type> Narrowable = { };
     static inline std::string packTemplate = "q_*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<long long>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "long long*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3286,30 +3024,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { };
     static inline std::set<ruby_value_type> Narrowable = { };
     static inline std::string packTemplate = "Q_*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<unsigned long long>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "unsigned long long*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3323,30 +3037,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { RUBY_T_FIXNUM };
     static inline std::set<ruby_value_type> Narrowable = { RUBY_T_FLOAT };
     static inline std::string packTemplate = "f*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<float>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "float*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3360,30 +3050,6 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Castable = { RUBY_T_FIXNUM, RUBY_T_BIGNUM };
     static inline std::set<ruby_value_type> Narrowable = { };
     static inline std::string packTemplate = "d*";
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<double>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "double*" };
-    static inline VALUE klass_ = Qnil;
   };
 
   template<>
@@ -3393,31 +3059,40 @@ namespace Rice::detail
     static inline std::set<ruby_value_type> Exact = { };
     static inline std::set<ruby_value_type> Castable = { };
     static inline std::set<ruby_value_type> Narrowable = { };
-
-    static rb_data_type_t* ruby_data_type()
-    {
-      return &ruby_data_type_;
-    }
-
-    static VALUE klass()
-    {
-      if (klass_ == Qnil)
-      {
-        std::string name = detail::typeName(typeid(RubyType<void>));
-        std::string klassName = detail::rubyClassName(name);
-        Identifier id(klassName);
-        Module rb_mRice = define_module("Rice");
-        Class klass = define_class_under(rb_mRice, id);
-        klass.undef_creation_funcs();
-        klass_ = klass;
-      }
-      return klass_;
-    }
-
-  private:
-    static inline rb_data_type_t ruby_data_type_ = { "void*" };
-    static inline VALUE klass_ = Qnil;
   };
+}
+
+namespace Rice::detail
+{
+  template<typename T>
+  inline Data_Type<T> define_ruby_type()
+  {
+    std::string name = detail::typeName(typeid(T*));
+    std::string klassName = detail::rubyClassName(name);
+    Identifier id(klassName);
+
+    Module rb_mRice = define_module("Rice");
+    return define_class_under<T>(rb_mRice, id);
+  }
+
+  inline void define_ruby_types()
+  {
+    define_ruby_type<bool>();
+    define_ruby_type<char>();
+    define_ruby_type<signed char>();
+    define_ruby_type<unsigned char>();
+    define_ruby_type<short>();
+    define_ruby_type<unsigned short>();
+    define_ruby_type<int>();
+    define_ruby_type<unsigned int>();
+    define_ruby_type<long>();
+    define_ruby_type<unsigned long>();
+    define_ruby_type<long long>();
+    define_ruby_type<unsigned long long>();
+    define_ruby_type<float>();
+    define_ruby_type<double>();
+    define_ruby_type<void>();
+  }
 }
 // =========   Wrapper.hpp   =========
 
@@ -3908,7 +3583,7 @@ namespace Rice
   };
 
   template<typename T>
-  Data_Type<T> define_buffer();
+  Data_Type<Buffer<T>> define_buffer();
 
   void define_fundamental_buffer_types();
 }
@@ -3980,11 +3655,11 @@ namespace Rice
       }
       case RUBY_T_DATA:
       {
-        if (RTYPEDDATA_TYPE(value) == RubyType_T::ruby_data_type())
+        if (Data_Type<T>::is_descendant(value))
         {
           this->m_size = 1;
           this->m_buffer = new T[this->m_size]();
-          this->m_buffer[0] = *detail::unwrap<T>(value, RubyType_T::ruby_data_type(), false);
+          this->m_buffer[0] = *detail::unwrap<T>(value, Data_Type<T>::ruby_data_type(), false);
           this->m_owner = false;
           break;
         }
@@ -4324,7 +3999,7 @@ namespace Rice
       T** ptr = this->m_outer + offset;
       T** end = this->m_outer + offset + count;
 
-      for (ptr; ptr < end; ptr++)
+      for (; ptr < end; ptr++)
       {
         Buffer<T> buffer(*ptr);
         result.push(std::move(buffer));
@@ -4358,9 +4033,10 @@ namespace Rice
   }
 
   // ------  define_buffer ----------
-  template<typename Buffer_T>
-  inline Data_Type<Buffer_T> define_buffer()
+  template<typename T>
+  inline Data_Type<Buffer<T>> define_buffer()
   {
+    using Buffer_T = Buffer<T>;
     std::string name = detail::typeName(typeid(Buffer_T));
     std::string klassName = detail::rubyClassName(name);
     Module rb_mRice = define_module("Rice");
@@ -4379,34 +4055,34 @@ namespace Rice
 
   inline void define_fundamental_buffer_types()
   {
-    define_buffer<Buffer<bool>>();
-    define_buffer<Buffer<int>>();
-    define_buffer<Buffer<int*>>();
-    define_buffer<Buffer<unsigned int>>();
-    define_buffer<Buffer<unsigned int*>>();
-    define_buffer<Buffer<char>>();
-    define_buffer<Buffer<char*>>();
-    define_buffer<Buffer<unsigned char>>();
-    define_buffer<Buffer<unsigned char*>>();
-    define_buffer<Buffer<signed char>>();
-    define_buffer<Buffer<signed char*>>();
-    define_buffer<Buffer<double>>();
-    define_buffer<Buffer<double*>>();
-    define_buffer<Buffer<float>>();
-    define_buffer<Buffer<float*>>();
-    define_buffer<Buffer<long>>();
-    define_buffer<Buffer<long*>>();
-    define_buffer<Buffer<unsigned long>>();
-    define_buffer<Buffer<unsigned long*>>();
-    define_buffer<Buffer<long long>>();
-    define_buffer<Buffer<long long*>>();
-    define_buffer<Buffer<unsigned long long>>();
-    define_buffer<Buffer<unsigned long long*>>();
-    define_buffer<Buffer<short>>();
-    define_buffer<Buffer<short*>>();
-    define_buffer<Buffer<unsigned short>>();
-    define_buffer<Buffer<unsigned short*>>();
-    define_buffer<Buffer<void>>();
+    define_buffer<bool>();
+    define_buffer<int>();
+    define_buffer<int*>();
+    define_buffer<unsigned int>();
+    define_buffer<unsigned int*>();
+    define_buffer<char>();
+    define_buffer<char*>();
+    define_buffer<unsigned char>();
+    define_buffer<unsigned char*>();
+    define_buffer<signed char>();
+    define_buffer<signed char*>();
+    define_buffer<double>();
+    define_buffer<double*>();
+    define_buffer<float>();
+    define_buffer<float*>();
+    define_buffer<long>();
+    define_buffer<long*>();
+    define_buffer<unsigned long>();
+    define_buffer<unsigned long*>();
+    define_buffer<long long>();
+    define_buffer<long long*>();
+    define_buffer<unsigned long long>();
+    define_buffer<unsigned long long*>();
+    define_buffer<short>();
+    define_buffer<short*>();
+    define_buffer<unsigned short>();
+    define_buffer<unsigned short*>();
+    define_buffer<void>();
   }
 }
 
@@ -4421,7 +4097,7 @@ namespace Rice::detail
 
       if (!Data_Type<Buffer<T>>::is_defined())
       {
-        define_buffer<Buffer<T>>();
+        define_buffer<T>();
       }
 
       return true;
@@ -11059,7 +10735,7 @@ namespace Rice
   template<typename T>
   inline Array String::unpack() const
   {
-    return this->call("unpack", detail::RubyType<T>::packTemplate);
+    return this->call("unpack", detail::RubyType<T>::packTemplate.c_str());
   }
 
   inline Identifier String::intern() const
@@ -11154,7 +10830,7 @@ namespace Rice
     return RARRAY_LEN(this->value());
   }
 
-  inline String Array::join(std::string separator)
+  inline String Array::join(char* separator)
   {
     return this->call("join", separator);
   }
@@ -11162,7 +10838,8 @@ namespace Rice
   template<typename T>
   String Array::pack()
   {
-    return this->call("pack", detail::RubyType<T>::packTemplate);
+    // Use .c_str so that the stl.hpp header is not required
+    return this->call("pack", detail::RubyType<T>::packTemplate.c_str());
   }
 
   inline Object Array::operator[](long index) const
@@ -13003,6 +12680,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     VALUE convert(const T& data)
     {
@@ -13030,6 +12715,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     To_Ruby() = default;
 
@@ -13066,6 +12759,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     To_Ruby() = default;
 
@@ -13106,6 +12807,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     To_Ruby() = default;
 
@@ -13146,6 +12855,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     To_Ruby() = default;
 
@@ -13204,6 +12921,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> || !std::is_same_v<T, std::unordered_map<T, T>> ||
+                  !std::is_same_v<T, std::monostate> || !std::is_same_v<T, std::multimap<T, T>> ||
+                  !std::is_same_v<T, std::optional<T>> || !std::is_same_v<T, std::pair<T, T>> ||
+                  !std::is_same_v<T, std::set<T>> || !std::is_same_v<T, std::string> ||
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     From_Ruby() = default;
 
@@ -13266,6 +12991,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>>   && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate>   && !std::is_same_v<T, std::multimap<T, T>>      &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>>          &&
+                  !std::is_same_v<T, std::set<T>>      && !std::is_same_v<T, std::string>              &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     From_Ruby() = default;
 
@@ -13308,6 +13041,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     From_Ruby() = default;
 
@@ -13354,6 +13095,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
     using Intrinsic_T = intrinsic_type<T>;
 
   public:
@@ -13426,6 +13175,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     From_Ruby() = default;
 
@@ -13468,6 +13225,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
     using Intrinsic_T = intrinsic_type<T>;
   public:
     From_Ruby() = default;
@@ -13526,6 +13291,14 @@ namespace Rice::detail
   {
     static_assert(!std::is_fundamental_v<intrinsic_type<T>>,
                   "Data_Object cannot be used with fundamental types");
+
+    static_assert(!std::is_same_v<T, std::map<T, T>> && !std::is_same_v<T, std::unordered_map<T, T>> &&
+                  !std::is_same_v<T, std::monostate> && !std::is_same_v<T, std::multimap<T, T>> &&
+                  !std::is_same_v<T, std::optional<T>> && !std::is_same_v<T, std::pair<T, T>> &&
+                  !std::is_same_v<T, std::set<T>> && !std::is_same_v<T, std::string> &&
+                  !std::is_same_v<T, std::vector<T>>,
+                  "Please include rice/stl.hpp header for STL support");
+
   public:
     Convertible is_convertible(VALUE value)
     {
@@ -13640,15 +13413,15 @@ namespace Rice
     // First we need a constructor
     klass.define_constructor(Constructor<Enum_T>());
 
-    klass.define_method("to_s", [](Enum_T& self) -> std::string
+    klass.define_method("to_s", [](Enum_T& self) -> String
       {
-        return std::string(valuesToNames_[self]);
+        return String(valuesToNames_[self]);
       })
       .define_method("to_int", [](Enum_T& self) ->  Underlying_T
       {
         return (Underlying_T)(self);
       })
-      .define_method("coerce", [](Enum_T& self, Underlying_T& other) -> std::tuple<Enum_T, Enum_T>
+      .define_method("coerce", [](Enum_T& self, Underlying_T& other) -> Array
       {
         /* Other will be a numeric value that matches the underlying type of the enum, for example an int.
            Convert that to the enum type and then create new Ruby object to wrap it. This then enables code
@@ -13659,7 +13432,11 @@ namespace Rice
         Colors::Red | Colors:Blue returns an integer. Then this method converts the integer back into an Enum
         instance so that Colors:Blue | Colors:Green works. */
         Enum_T otherEnum = (Enum_T)other;
-        return std::tie<Enum_T, Enum_T>(self, otherEnum);
+
+        Array result;
+        result.push(self);
+        result.push(otherEnum);
+        return result;
       })
       .define_method("inspect", [](Enum_T& self)
       {
@@ -13930,4 +13707,32 @@ namespace Rice::detail
 }
 
 
+// Initialize Rice
+
+// =========   Init.hpp   =========
+
+namespace Rice
+{
+  // This class is used to initialize Rice when a Rice extension is loaded.
+  // It defines template instantiations for the Buffer and RubyTypes classes.
+  // To use it add the following code to your Init_ function when loading a 
+  // Rice extension:
+  //
+  //    static Rice::Init init;
+  class Init
+  {
+  public:
+    Init();
+  };
+}
+
+// =========   Init.ipp   =========
+namespace Rice
+{
+  inline Init::Init()
+  {
+    define_fundamental_buffer_types();
+    detail::define_ruby_types();
+  };
+}
 #endif // Rice__hpp_

--- a/rice/Buffer.hpp
+++ b/rice/Buffer.hpp
@@ -87,7 +87,7 @@ namespace Rice
   };
 
   template<typename T>
-  Data_Type<T> define_buffer();
+  Data_Type<Buffer<T>> define_buffer();
 
   void define_fundamental_buffer_types();
 }

--- a/rice/Buffer.ipp
+++ b/rice/Buffer.ipp
@@ -442,9 +442,10 @@ namespace Rice
   }
 
   // ------  define_buffer ----------
-  template<typename Buffer_T>
-  inline Data_Type<Buffer_T> define_buffer()
+  template<typename T>
+  inline Data_Type<Buffer<T>> define_buffer()
   {
+    using Buffer_T = Buffer<T>;
     std::string name = detail::typeName(typeid(Buffer_T));
     std::string klassName = detail::rubyClassName(name);
     Module rb_mRice = define_module("Rice");
@@ -463,34 +464,34 @@ namespace Rice
 
   inline void define_fundamental_buffer_types()
   {
-    define_buffer<Buffer<bool>>();
-    define_buffer<Buffer<int>>();
-    define_buffer<Buffer<int*>>();
-    define_buffer<Buffer<unsigned int>>();
-    define_buffer<Buffer<unsigned int*>>();
-    define_buffer<Buffer<char>>();
-    define_buffer<Buffer<char*>>();
-    define_buffer<Buffer<unsigned char>>();
-    define_buffer<Buffer<unsigned char*>>();
-    define_buffer<Buffer<signed char>>();
-    define_buffer<Buffer<signed char*>>();
-    define_buffer<Buffer<double>>();
-    define_buffer<Buffer<double*>>();
-    define_buffer<Buffer<float>>();
-    define_buffer<Buffer<float*>>();
-    define_buffer<Buffer<long>>();
-    define_buffer<Buffer<long*>>();
-    define_buffer<Buffer<unsigned long>>();
-    define_buffer<Buffer<unsigned long*>>();
-    define_buffer<Buffer<long long>>();
-    define_buffer<Buffer<long long*>>();
-    define_buffer<Buffer<unsigned long long>>();
-    define_buffer<Buffer<unsigned long long*>>();
-    define_buffer<Buffer<short>>();
-    define_buffer<Buffer<short*>>();
-    define_buffer<Buffer<unsigned short>>();
-    define_buffer<Buffer<unsigned short*>>();
-    define_buffer<Buffer<void>>();
+    define_buffer<bool>();
+    define_buffer<int>();
+    define_buffer<int*>();
+    define_buffer<unsigned int>();
+    define_buffer<unsigned int*>();
+    define_buffer<char>();
+    define_buffer<char*>();
+    define_buffer<unsigned char>();
+    define_buffer<unsigned char*>();
+    define_buffer<signed char>();
+    define_buffer<signed char*>();
+    define_buffer<double>();
+    define_buffer<double*>();
+    define_buffer<float>();
+    define_buffer<float*>();
+    define_buffer<long>();
+    define_buffer<long*>();
+    define_buffer<unsigned long>();
+    define_buffer<unsigned long*>();
+    define_buffer<long long>();
+    define_buffer<long long*>();
+    define_buffer<unsigned long long>();
+    define_buffer<unsigned long long*>();
+    define_buffer<short>();
+    define_buffer<short*>();
+    define_buffer<unsigned short>();
+    define_buffer<unsigned short*>();
+    define_buffer<void>();
   }
 }
 
@@ -505,7 +506,7 @@ namespace Rice::detail
 
       if (!Data_Type<Buffer<T>>::is_defined())
       {
-        define_buffer<Buffer<T>>();
+        define_buffer<T>();
       }
 
       return true;

--- a/rice/stl/map.hpp
+++ b/rice/stl/map.hpp
@@ -3,8 +3,8 @@
 
 namespace Rice
 {
-  template<typename U>
-  Data_Type<U> define_map(std::string name = "");
+  template<typename K, typename T>
+  Data_Type<std::map<K, T>> define_map(std::string name = "");
 }
 
 #include "map.ipp"

--- a/rice/stl/map.ipp
+++ b/rice/stl/map.ipp
@@ -34,7 +34,7 @@ namespace Rice
 
       void register_pair()
       {
-        define_pair_auto<Value_T>();
+        define_pair<const Key_T, Mapped_T>();
       }
 
       void define_constructor()
@@ -232,40 +232,43 @@ namespace Rice
     };
   } // namespace
 
-  template<typename T>
-  Data_Type<T> define_map(std::string klassName)
+  template<typename Key, typename T>
+  Data_Type<std::map<Key, T>> define_map(std::string klassName)
   {
+    using Map_T = std::map<Key, T>;
+    using Data_Type_T = Data_Type<Map_T>;
+
     if (klassName.empty())
     {
-      std::string typeName = detail::typeName(typeid(T));
+      std::string typeName = detail::typeName(typeid(Map_T));
       klassName = detail::rubyClassName(typeName);
     }
 
     Module rb_mStd = define_module("Std");
-    if (Data_Type<T>::check_defined(klassName, rb_mStd))
+    if (Data_Type_T::check_defined(klassName, rb_mStd))
     {
-      return Data_Type<T>();
+      return Data_Type_T();
     }
 
     Identifier id(klassName);
-    Data_Type<T> result = define_class_under<detail::intrinsic_type<T>>(rb_mStd, id);
+    Data_Type_T result = define_class_under<detail::intrinsic_type<Map_T>>(rb_mStd, id);
     stl::MapHelper helper(result);
     return result;
   }
 
   namespace detail
   {
-    template<typename T, typename U>
-    struct Type<std::map<T, U>>
+    template<typename Key_T, typename T>
+    struct Type<std::map<Key_T, T>>
     {
       static bool verify()
       {
+        Type<Key_T>::verify();
         Type<T>::verify();
-        Type<U>::verify();
 
-        if (!Data_Type<std::map<T, U>>::is_defined())
+        if (!Data_Type<std::map<Key_T, T>>::is_defined())
         {
-          define_map<std::map<T, U>>();
+          define_map<Key_T, T>();
         }
 
         return true;

--- a/rice/stl/multimap.hpp
+++ b/rice/stl/multimap.hpp
@@ -5,8 +5,8 @@
 
 namespace Rice
 {
-  template<typename U>
-  Data_Type<U> define_multimap(std::string name = "");
+  template<typename K, typename T>
+  Data_Type<std::multimap<K, T>> define_multimap(std::string name = "");
 }
 
 #include "multimap.ipp"

--- a/rice/stl/multimap.ipp
+++ b/rice/stl/multimap.ipp
@@ -33,7 +33,7 @@ namespace Rice
 
       void register_pair()
       {
-        define_pair_auto<Value_T>();
+        define_pair<const Key_T, Mapped_T>();
       }
 
       void define_constructor()
@@ -214,23 +214,26 @@ namespace Rice
     };
   } // namespace
 
-  template<typename T>
-  Data_Type<T> define_multimap(std::string klassName)
+  template<typename Key, typename T>
+  Data_Type<std::multimap<Key, T>> define_multimap(std::string klassName)
   {
+    using MultiMap_T = std::multimap<Key, T>;
+    using Data_Type_T = Data_Type<MultiMap_T>;
+
     if (klassName.empty())
     {
-      std::string typeName = detail::typeName(typeid(T));
+      std::string typeName = detail::typeName(typeid(MultiMap_T));
       klassName = detail::rubyClassName(typeName);
     }
 
     Module rb_mStd = define_module("Std");
-    if (Data_Type<T>::check_defined(klassName, rb_mStd))
+    if (Data_Type_T::check_defined(klassName, rb_mStd))
     {
-      return Data_Type<T>();
+      return Data_Type_T();
     }
 
     Identifier id(klassName);
-    Data_Type<T> result = define_class_under<detail::intrinsic_type<T>>(rb_mStd, id);
+    Data_Type_T result = define_class_under<detail::intrinsic_type<MultiMap_T>>(rb_mStd, id);
     stl::MultimapHelper helper(result);
     return result;
   }
@@ -263,17 +266,17 @@ namespace Rice
       return result;
     }
 
-    template<typename T, typename U>
-    struct Type<std::multimap<T, U>>
+    template<typename Key_T, typename T>
+    struct Type<std::multimap<Key_T, T>>
     {
       static bool verify()
       {
-        Type<T>::verify();
-        Type<U>::verify();
+        Type<Key_T>::verify();
+        Type<Key_T>::verify();
 
-        if (!Data_Type<std::multimap<T, U>>::is_defined())
+        if (!Data_Type<std::multimap<Key_T, T>>::is_defined())
         {
-          define_multimap<std::multimap<T, U>>();
+          define_multimap<Key_T, T>();
         }
 
         return true;

--- a/rice/stl/pair.hpp
+++ b/rice/stl/pair.hpp
@@ -3,11 +3,8 @@
 
 namespace Rice
 {
-  template<typename T>
-  Data_Type<T> define_pair(std::string name);
-
-  template<typename T>
-  Data_Type<T> define_pair_under(Object parent, std::string name);
+  template<typename T1, typename T2>
+  Data_Type<std::pair<T1, T2>> define_pair(std::string klassName = "");
 }
 
 #include "pair.ipp"

--- a/rice/stl/pair.ipp
+++ b/rice/stl/pair.ipp
@@ -109,41 +109,30 @@ namespace Rice
     };
   } // namespace
 
-  template<typename T>
-  Data_Type<T> define_pair_under(Object parent, std::string name)
+  template<typename T1, typename T2>
+  Data_Type<std::pair<T1, T2>> define_pair(std::string klassName)
   {
-    if (Data_Type<T>::check_defined(name, parent))
+    using Pair_T = std::pair<T1, T2>;
+    using Data_Type_T = Data_Type<Pair_T>;
+
+    if (klassName.empty())
     {
-      return Data_Type<T>();
+      std::string typeName = detail::typeName(typeid(Pair_T));
+      klassName = detail::rubyClassName(typeName);
     }
 
-    Data_Type<T> result = define_class_under<detail::intrinsic_type<T>>(parent, name.c_str());
+    Module rb_mStd = define_module("Std");
+    if (Data_Type_T::check_defined(klassName, rb_mStd))
+    {
+      return Data_Type_T();
+    }
+
+    Identifier id(klassName);
+    Data_Type_T result = define_class_under<detail::intrinsic_type<Pair_T>>(rb_mStd, id);
     stl::PairHelper helper(result);
     return result;
   }
 
-  template<typename T>
-  Data_Type<T> define_pair(std::string name)
-  {
-    if (Data_Type<T>::check_defined(name))
-    {
-      return Data_Type<T>();
-    }
-
-    Data_Type<T> result = define_class<detail::intrinsic_type<T>>(name.c_str());
-    stl::PairHelper<T> helper(result);
-    return result;
-  }
-
-  template<typename T>
-  Data_Type<T> define_pair_auto()
-  {
-    Module rb_mStd = define_module("Std");
-    std::string name = detail::typeName(typeid(T));
-    std::string klassName = detail::rubyClassName(name);
-    return define_pair_under<T>(rb_mStd, klassName);
-  }
-   
   namespace detail
   {
     template<typename T1, typename T2>
@@ -156,7 +145,7 @@ namespace Rice
 
         if (!Data_Type<std::pair<T1, T2>>::is_defined())
         {
-          define_pair_auto<std::pair<T1, T2>>();
+          define_pair<T1, T2>();
         }
 
         return true;

--- a/rice/stl/set.hpp
+++ b/rice/stl/set.hpp
@@ -4,7 +4,7 @@
 namespace Rice
 {
   template<typename T>
-  Data_Type<T> define_set(std::string klassName = "");
+  Data_Type<std::set<T>> define_set(std::string klassName = "");
 }
 
 #include "set.ipp"

--- a/rice/stl/set.ipp
+++ b/rice/stl/set.ipp
@@ -228,24 +228,26 @@ namespace Rice
     };
   } // namespace
 
-
   template<typename T>
-  Data_Type<T> define_set(std::string klassName)
+  Data_Type<std::set<T>> define_set(std::string klassName)
   {
+    using Set_T = std::set<T>;
+    using Data_Type_T = Data_Type<Set_T>;
+
     if (klassName.empty())
     {
-      std::string typeName = detail::typeName(typeid(T));
+      std::string typeName = detail::typeName(typeid(Set_T));
       klassName = detail::rubyClassName(typeName);
     }
 
     Module rb_mStd = define_module("Std");
-    if (Data_Type<T>::check_defined(klassName, rb_mStd))
+    if (Data_Type_T::check_defined(klassName, rb_mStd))
     {
-      return Data_Type<T>();
+      return Data_Type_T();
     }
 
     Identifier id(klassName);
-    Data_Type<T> result = define_class_under<detail::intrinsic_type<T>>(rb_mStd, id);
+    Data_Type_T result = define_class_under<detail::intrinsic_type<Set_T>>(rb_mStd, id);
     stl::SetHelper helper(result);
     return result;
   }
@@ -284,7 +286,7 @@ namespace Rice
 
         if (!Data_Type<std::set<T>>::is_defined())
         {
-          define_set<std::set<T>>();
+          define_set<T>();
         }
 
         return true;

--- a/rice/stl/shared_ptr.hpp
+++ b/rice/stl/shared_ptr.hpp
@@ -20,7 +20,7 @@ namespace Rice::detail
 namespace Rice
 {
   template<typename T>
-  Data_Type<T> define_shared_ptr(std::string klassName = "");
+  Data_Type<std::shared_ptr<T>> define_shared_ptr(std::string klassName = "");
 }
 
 #include "shared_ptr.ipp"

--- a/rice/stl/shared_ptr.ipp
+++ b/rice/stl/shared_ptr.ipp
@@ -4,23 +4,26 @@
 namespace Rice
 {
   template<typename T>
-  inline Data_Type<T> define_shared_ptr(std::string klassName)
+  Data_Type<std::shared_ptr<T>> define_shared_ptr(std::string klassName)
   {
+    using SharedPtr_T = std::shared_ptr<T>;
+    using Data_Type_T = Data_Type<SharedPtr_T>;
+
     if (klassName.empty())
     {
-      std::string typeName = detail::typeName(typeid(T));
+      std::string typeName = detail::typeName(typeid(SharedPtr_T));
       klassName = detail::rubyClassName(typeName);
     }
 
     Module rb_mStd = define_module("Std");
-    if (Data_Type<T>::check_defined(klassName, rb_mStd))
+    if (Data_Type_T::check_defined(klassName, rb_mStd))
     {
-      return Data_Type<T>();
+      return Data_Type_T();
     }
 
     Identifier id(klassName);
-    Data_Type<T> result = define_class_under<T>(rb_mStd, id).
-      define_constructor(Constructor<T, typename T::element_type*>(), Arg("value").takeOwnership());
+    Data_Type_T result = define_class_under<detail::intrinsic_type<SharedPtr_T>>(rb_mStd, id).
+      define_constructor(Constructor<SharedPtr_T, typename SharedPtr_T::element_type*>(), Arg("value").takeOwnership());
 
     return result;
   }

--- a/rice/stl/unordered_map.hpp
+++ b/rice/stl/unordered_map.hpp
@@ -3,8 +3,8 @@
 
 namespace Rice
 {
-  template<typename U>
-  Data_Type<U> define_unordered_map(std::string name = "");
+  template<typename Key, typename T>
+  Data_Type<std::unordered_map<Key, T>> define_unordered_map(std::string name = "");
 }
 
 #include "unordered_map.ipp"

--- a/rice/stl/unordered_map.ipp
+++ b/rice/stl/unordered_map.ipp
@@ -34,7 +34,7 @@ namespace Rice
 
       void register_pair()
       {
-        define_pair_auto<Value_T>();
+        define_pair<const Key_T, T>();
       }
 
       void define_constructor()
@@ -232,40 +232,43 @@ namespace Rice
     };
   } // namespace
 
-  template<typename T>
-  Data_Type<T> define_unordered_map(std::string klassName)
+  template<typename Key, typename T>
+  Data_Type<std::unordered_map<Key, T>> define_unordered_map(std::string klassName)
   {
+    using UnorderedMap_T = std::unordered_map<Key, T>;
+    using Data_Type_T = Data_Type<UnorderedMap_T>;
+
     if (klassName.empty())
     {
-      std::string typeName = detail::typeName(typeid(T));
+      std::string typeName = detail::typeName(typeid(UnorderedMap_T));
       klassName = detail::rubyClassName(typeName);
     }
 
     Module rb_mStd = define_module("Std");
-    if (Data_Type<T>::check_defined(klassName, rb_mStd))
+    if (Data_Type_T::check_defined(klassName, rb_mStd))
     {
-      return Data_Type<T>();
+      return Data_Type_T();
     }
 
     Identifier id(klassName);
-    Data_Type<T> result = define_class_under<detail::intrinsic_type<T>>(rb_mStd, id);
+    Data_Type_T result = define_class_under<detail::intrinsic_type<UnorderedMap_T>>(rb_mStd, id);
     stl::UnorderedMapHelper helper(result);
     return result;
   }
 
   namespace detail
   {
-    template<typename T, typename U>
-    struct Type<std::unordered_map<T, U>>
+    template<typename Key_T, typename T>
+    struct Type<std::unordered_map<Key_T, T>>
     {
       static bool verify()
       {
+        Type<Key_T>::verify();
         Type<T>::verify();
-        Type<U>::verify();
 
-        if (!Data_Type<std::unordered_map<T, U>>::is_defined())
+        if (!Data_Type<std::unordered_map<Key_T, T>>::is_defined())
         {
-          define_unordered_map<std::unordered_map<T, U>>();
+          define_unordered_map<Key_T, T>();
         }
 
         return true;

--- a/rice/stl/vector.hpp
+++ b/rice/stl/vector.hpp
@@ -4,7 +4,7 @@
 namespace Rice
 {
   template<typename T>
-  Data_Type<T> define_vector(std::string name= "" );
+  Data_Type<std::vector<T>> define_vector(std::string name = "" );
 }
 
 #include "vector.ipp"

--- a/rice/stl/vector.ipp
+++ b/rice/stl/vector.ipp
@@ -349,22 +349,25 @@ namespace Rice
   } // namespace
 
   template<typename T>
-  Data_Type<T> define_vector(std::string klassName)
+  Data_Type<std::vector<T>> define_vector(std::string klassName)
   {
+    using Vector_T = std::vector<T>;
+    using Data_Type_T = Data_Type<Vector_T>;
+
     if (klassName.empty())
     {
-      std::string typeName = detail::typeName(typeid(T));
+      std::string typeName = detail::typeName(typeid(Vector_T));
       klassName = detail::rubyClassName(typeName);
     }
 
     Module rb_mStd = define_module("Std");
-    if (Data_Type<T>::check_defined(klassName, rb_mStd))
+    if (Data_Type_T::check_defined(klassName, rb_mStd))
     {
-      return Data_Type<T>();
+      return Data_Type_T();
     }
 
     Identifier id(klassName);
-    Data_Type<T> result = define_class_under<detail::intrinsic_type<T>>(rb_mStd, id);
+    Data_Type_T result = define_class_under<detail::intrinsic_type<Vector_T>>(rb_mStd, id);
     stl::VectorHelper helper(result);
     return result;
   }
@@ -381,7 +384,7 @@ namespace Rice
 
         if (!Data_Type<std::vector<T>>::is_defined())
         {
-          define_vector<std::vector<T>>();
+          define_vector<T>();
         }
 
         return true;

--- a/test/test_Buffer.cpp
+++ b/test/test_Buffer.cpp
@@ -21,7 +21,7 @@ TEARDOWN(Buffer)
 
 TESTCASE(Char)
 {
-  define_buffer<Buffer<char>>();
+  define_buffer<char>();
 
   Module m = define_module("BufferTesting");
 
@@ -45,7 +45,7 @@ TESTCASE(Char)
 
 TESTCASE(CharArray)
 {
-  define_buffer<Buffer<char>>();
+  define_buffer<char>();
 
   Module m = define_module("BufferTesting");
 
@@ -66,7 +66,7 @@ TESTCASE(CharArray)
 
 TESTCASE(signed_char_pointer)
 {
-  define_buffer<Buffer<signed char>>();
+  define_buffer<signed char>();
   Module m = define_module("Testing");
 
   std::string code = u8R"(Rice::Buffer≺signed char≻.new("my string"))";
@@ -94,7 +94,7 @@ TESTCASE(signed_char_pointer)
 
 TESTCASE(char_pointer_const)
 {
-  define_buffer<Buffer<char>>();
+  define_buffer<char>();
   Module m = define_module("Testing");
 
   std::string code = u8R"(Rice::Buffer≺char≻.new("my string"))";
@@ -117,7 +117,7 @@ TESTCASE(char_pointer_const)
 
 TESTCASE(unsigned_char_pointer)
 {
-  define_buffer<Buffer<unsigned char>>();
+  define_buffer<unsigned char>();
   Module m = define_module("Testing");
 
   std::string code = u8R"(Rice::Buffer≺unsigned char≻.new([0, 127, 128, 255, 256, -128, -129, -255]))";
@@ -153,7 +153,7 @@ TESTCASE(unsigned_char_pointer)
 
 TESTCASE(float_array_array)
 {
-  define_buffer<Buffer<float*>>();
+  define_buffer<float*>();
   Module m = define_module("Testing");
 
   std::string code = R"(Rice::Buffer≺float∗≻.new([[1.1, 2.2], [3.3, 4.4], [5.5, 6.6]]))";
@@ -174,7 +174,7 @@ TESTCASE(float_array_array)
 
 TESTCASE(wrong_type)
 {
-  define_buffer<Buffer<float*>>();
+  define_buffer<float*>();
   Module m = define_module("Testing");
 
   std::string code = R"(Rice::Buffer≺float∗≻.new([[4, "bad"], [2, 1]]))";

--- a/test/test_Data_Object.cpp
+++ b/test/test_Data_Object.cpp
@@ -205,15 +205,13 @@ TESTCASE(data_object_from_ruby_copy)
 
 TESTCASE(data_object_return_array)
 {
-  define_buffer<Buffer<MyDataType>>();
+  define_buffer<MyDataType>();
   Module m = define_module("DataObjectTest").
     define_module_function("data_types", &dataTypes, Return().setArray()).
     define_module_function("data_types_count", &dataTypesCount);
 
   std::string code = R"(buffer = data_types
-puts buffer
                         count = data_types_count
-puts count
                         buffer.to_a(0, count))";
 
   Array dataTypes = m.module_eval(code);
@@ -225,7 +223,6 @@ puts count
   ASSERT_EQUAL(3, vector[2].x);
 }
 
-/*
 TESTCASE(data_object_ruby_custom_mark)
 {
   test_ruby_mark_called = false;
@@ -266,4 +263,3 @@ TESTCASE(data_object_ruby_custom_free)
 //  ASSERT_EQUAL(true, test_destructor_called);
 #endif
 }
-*/

--- a/test/test_Data_Type.cpp
+++ b/test/test_Data_Type.cpp
@@ -653,7 +653,7 @@ namespace
 
 TESTCASE(pointerToPointer)
 {
-  define_buffer<Buffer<BigObject*>>();
+  define_buffer<BigObject*>();
 
   Module m = define_module("DataTypePointerToPointer");
 
@@ -821,7 +821,7 @@ namespace RangesTest
 
 TESTCASE(array_of_ranges)
 {
-  define_buffer<Buffer<RangesTest::RangeCustom>>();
+  define_buffer<RangesTest::RangeCustom>();
 
   Module m = define_module("CustomRanges");
 
@@ -846,7 +846,7 @@ TESTCASE(array_of_ranges)
 
 TESTCASE(pointer_of_ranges)
 {
-  define_buffer<Buffer<RangesTest::RangeCustom>>();
+  define_buffer<RangesTest::RangeCustom>();
 
   Module m = define_module("CustomRanges");
 
@@ -871,7 +871,7 @@ TESTCASE(pointer_of_ranges)
 
 TESTCASE(pointer_of_ranges_wrong)
 {
-  define_buffer<Buffer<RangesTest::RangeCustom>>();
+  define_buffer<RangesTest::RangeCustom>();
 
   Module m = define_module("CustomRanges");
 
@@ -898,7 +898,7 @@ TESTCASE(pointer_of_ranges_wrong)
 
 TESTCASE(pointer_of_pointer_ranges)
 {
-  define_buffer<Buffer<RangesTest::RangeCustom*>>();
+  define_buffer<RangesTest::RangeCustom*>();
 
   Module m = define_module("CustomRanges");
 

--- a/test/test_Stl_Map.cpp
+++ b/test/test_Stl_Map.cpp
@@ -47,7 +47,7 @@ TESTCASE(StringMap)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, std::string>>("StringMap");
+  Class c = define_map<std::string, std::string>("StringMap");
 
   Object map = m.module_eval("$map = Std::StringMap.new");
   Object result = map.call("size");
@@ -66,7 +66,7 @@ TESTCASE(WrongType)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, std::string>>("StringMap");
+  Class c = define_map<std::string, std::string>("StringMap");
   Object map = m.module_eval("$map = Std::StringMap.new");
 
   ASSERT_EXCEPTION_CHECK(
@@ -84,7 +84,7 @@ TESTCASE(Empty)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, std::int32_t>>("IntMap");
+  Class c = define_map<std::string, std::int32_t>("IntMap");
   Object map = c.call("new");
 
   Object result = map.call("size");
@@ -98,7 +98,7 @@ TESTCASE(Include)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, std::int32_t>>("IntMap");
+  Class c = define_map<std::string, std::int32_t>("IntMap");
   Object map = c.call("new");
   map.call("[]=", "one", 1);
   map.call("[]=", "two", 2);
@@ -117,7 +117,7 @@ TESTCASE(Value)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, std::int32_t>>("IntMap");
+  Class c = define_map<std::string, std::int32_t>("IntMap");
   Object map = c.call("new");
   map.call("[]=", "one", 1);
   map.call("[]=", "two", 2);
@@ -133,7 +133,7 @@ TESTCASE(ToString)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, std::int32_t>>("IntMap");
+  Class c = define_map<std::string, std::int32_t>("IntMap");
   Object map = c.call("new");
   map.call("[]=", "one", 1);
   map.call("[]=", "two", 2);
@@ -151,7 +151,7 @@ TESTCASE(Update)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, std::string>>("StringMap");
+  Class c = define_map<std::string, std::string>("StringMap");
   Object map = c.call("new");
   map.call("[]=", "one", "original 1");
   map.call("[]=", "two", "original 2");
@@ -173,7 +173,7 @@ TESTCASE(Modify)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, int64_t>>("Int64Map");
+  Class c = define_map<std::string, int64_t>("Int64Map");
   Object map = c.call("new");
 
   Object result = map.call("[]=", "one", 3232323232);
@@ -192,7 +192,7 @@ TESTCASE(keysAndValues)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, int32_t>>("Int32Map");
+  Class c = define_map<std::string, int32_t>("Int32Map");
   Object map = c.call("new");
 
   map.call("[]=", "one", 1);
@@ -220,7 +220,7 @@ TESTCASE(Copy)
 {
   Module m = define_module("Testing");
 
-  Class c = define_map<std::map<std::string, double>>("DoubleMap");
+  Class c = define_map<std::string, double>("DoubleMap");
   Object object = c.call("new");
 
   object.call("[]=", "one", 11.1);
@@ -241,7 +241,7 @@ TESTCASE(Copy)
 TESTCASE(Iterate)
 {
   Module m = define_module("Testing");
-  Class c = define_map<std::map<std::string, int>>("IntMap");
+  Class c = define_map<std::string, int>("IntMap");
 
   std::string code = R"(map = Std::IntMap.new
                         map["five"] = 5
@@ -268,7 +268,7 @@ TESTCASE(Iterate)
 TESTCASE(ToEnum)
 {
   Module m = define_module("Testing");
-  Class c = define_map<std::map<std::string, int>>("IntMap");
+  Class c = define_map<std::string, int>("IntMap");
 
   std::string code = R"(map = Std::IntMap.new
                         map["five"] = 5
@@ -296,7 +296,7 @@ TESTCASE(ToEnum)
 TESTCASE(ToEnumSize)
 {
   Module m = define_module("TestingModule");
-  Class c = define_map<std::map<std::string, int>>("IntMap");
+  Class c = define_map<std::string, int>("IntMap");
 
   std::string code = R"(map = Std::IntMap.new
                         map["five"] = 5
@@ -332,7 +332,7 @@ TESTCASE(NotComparable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_map<std::map<std::string, NotComparable>>("NotComparableMap");
+  Class c = define_map<std::string, NotComparable>("NotComparableMap");
 
   Object map = c.call("new");
   map.call("[]=", "one", NotComparable(1));
@@ -351,7 +351,7 @@ TESTCASE(NotPrintable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_map<std::map<std::string, NotComparable>>("NotComparableMap");
+  Class c = define_map<std::string, NotComparable>("NotComparableMap");
 
   Object map = c.call("new");
   map.call("[]=", "one", NotComparable(1));
@@ -392,7 +392,7 @@ TESTCASE(Comparable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_map<std::map<std::string, Comparable>>("ComparableMap");
+  Class c = define_map<std::string, Comparable>("ComparableMap");
 
   Object map = c.call("new");
   
@@ -409,7 +409,7 @@ TESTCASE(Printable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_map<std::map<std::string, Comparable>>("ComparableMap");
+  Class c = define_map<std::string, Comparable>("ComparableMap");
 
   Object map = c.call("new");
   map.call("[]=", "one", Comparable(1));
@@ -458,7 +458,7 @@ TESTCASE(AutoRegisterReturn)
   ASSERT_EQUAL(Qtrue, result.value());
 
   // Now register the map again
-  define_map<std::map<std::string, std::complex<double>>>("ComplexMap");
+  define_map<std::string, std::complex<double>>("ComplexMap");
   code = R"(map = Std::ComplexMap.new)";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(map.class_of()));
@@ -496,7 +496,7 @@ namespace
 
 TESTCASE(DefaultValue)
 {
-  define_map<std::map<std::string, std::string>>("StringMap");
+  define_map<std::string, std::string>("StringMap");
   define_global_function("default_map", &defaultMap, Arg("strings") = std::map<std::string, std::string>{ {"one", "value 1"}, {"two", "value 2"}, {"three", "value 3"} });
 
   Module m = define_module("Testing");

--- a/test/test_Stl_Multimap.cpp
+++ b/test/test_Stl_Multimap.cpp
@@ -47,7 +47,7 @@ TESTCASE(StringMultimap)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, std::string>>("StringMultimap");
+  Class c = define_multimap<std::string, std::string>("StringMultimap");
 
   Object multimap = m.module_eval("$multimap = Std::StringMultimap.new");
   Object result = multimap.call("size");
@@ -66,7 +66,7 @@ TESTCASE(WrongType)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, std::string>>("StringMultimap");
+  Class c = define_multimap<std::string, std::string>("StringMultimap");
   Object multimap = m.module_eval("$multimap = Std::StringMultimap.new");
 
   ASSERT_EXCEPTION_CHECK(
@@ -84,7 +84,7 @@ TESTCASE(Empty)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, std::int32_t>>("IntMultimap");
+  Class c = define_multimap<std::string, std::int32_t>("IntMultimap");
   Object multimap = c.call("new");
 
   Object result = multimap.call("size");
@@ -98,7 +98,7 @@ TESTCASE(Include)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, std::int32_t>>("IntMultimap");
+  Class c = define_multimap<std::string, std::int32_t>("IntMultimap");
   Object multimap = c.call("new");
   multimap.call("insert", "one", 1);
   multimap.call("insert", "two", 2);
@@ -117,7 +117,7 @@ TESTCASE(Value)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, std::int32_t>>("IntMultimap");
+  Class c = define_multimap<std::string, std::int32_t>("IntMultimap");
   Object multimap = c.call("new");
   multimap.call("insert", "one", 1);
   multimap.call("insert", "two", 2);
@@ -133,7 +133,7 @@ TESTCASE(ToString)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, std::int32_t>>("IntMultimap");
+  Class c = define_multimap<std::string, std::int32_t>("IntMultimap");
   Object multimap = c.call("new");
   multimap.call("insert", "one", 1);
   multimap.call("insert", "two", 2);
@@ -151,7 +151,7 @@ TESTCASE(Update)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, std::string>>("StringMultimap");
+  Class c = define_multimap<std::string, std::string>("StringMultimap");
   Object multimap = c.call("new");
   multimap.call("insert", "one", "original 1");
   multimap.call("insert", "two", "original 2");
@@ -175,7 +175,7 @@ TESTCASE(Modify)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, int64_t>>("Int64Multimap");
+  Class c = define_multimap<std::string, int64_t>("Int64Multimap");
   Object multimap = c.call("new");
 
   Object result = multimap.call("insert", "one", 3232323232);
@@ -194,7 +194,7 @@ TESTCASE(keysAndValues)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, int32_t>>("Int32Multimap");
+  Class c = define_multimap<std::string, int32_t>("Int32Multimap");
   Object multimap = c.call("new");
 
   multimap.call("insert", "one", 1);
@@ -222,7 +222,7 @@ TESTCASE(Copy)
 {
   Module m = define_module("Testing");
 
-  Class c = define_multimap<std::multimap<std::string, double>>("DoubleMultimap");
+  Class c = define_multimap<std::string, double>("DoubleMultimap");
   Object object = c.call("new");
 
   object.call("insert", "one", 11.1);
@@ -238,7 +238,7 @@ TESTCASE(Copy)
 TESTCASE(Iterate)
 {
   Module m = define_module("Testing");
-  Class c = define_multimap<std::multimap<std::string, int>>("IntMultimap");
+  Class c = define_multimap<std::string, int>("IntMultimap");
 
   std::string code = R"(multimap = Std::IntMultimap.new
                         multimap.insert("five", 5)
@@ -265,7 +265,7 @@ TESTCASE(Iterate)
 TESTCASE(ToEnum)
 {
   Module m = define_module("Testing");
-  Class c = define_multimap<std::multimap<std::string, int>>("IntMultimap");
+  Class c = define_multimap<std::string, int>("IntMultimap");
 
   std::string code = R"(multimap = Std::IntMultimap.new
                         multimap.insert("five", 5)
@@ -293,7 +293,7 @@ TESTCASE(ToEnum)
 TESTCASE(ToEnumSize)
 {
   Module m = define_module("TestingModule");
-  Class c = define_multimap<std::multimap<std::string, int>>("IntMultimap");
+  Class c = define_multimap<std::string, int>("IntMultimap");
 
   std::string code = R"(multimap = Std::IntMultimap.new
                         multimap.insert("five", 5)
@@ -330,7 +330,7 @@ TESTCASE(NotComparable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_multimap<std::multimap<std::string, NotComparable>>("NotComparableMultimap");
+  Class c = define_multimap<std::string, NotComparable>("NotComparableMultimap");
 
   Object multimap = c.call("new");
   multimap.call("insert", "one", NotComparable(1));
@@ -349,7 +349,7 @@ TESTCASE(NotPrintable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_multimap<std::multimap<std::string, NotComparable>>("NotComparableMultimap");
+  Class c = define_multimap<std::string, NotComparable>("NotComparableMultimap");
 
   Object multimap = c.call("new");
   multimap.call("insert", "one", NotComparable(1));
@@ -390,7 +390,7 @@ TESTCASE(Comparable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_multimap<std::multimap<std::string, Comparable>>("ComparableMultimap");
+  Class c = define_multimap<std::string, Comparable>("ComparableMultimap");
 
   Object multimap = c.call("new");
   
@@ -407,7 +407,7 @@ TESTCASE(Printable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_multimap<std::multimap<std::string, Comparable>>("ComparableMultimap");
+  Class c = define_multimap<std::string, Comparable>("ComparableMultimap");
 
   Object multimap = c.call("new");
   multimap.call("insert", "one", Comparable(1));
@@ -458,13 +458,13 @@ TESTCASE(AutoRegisterReturn)
   ASSERT_EQUAL(Qtrue, result.value());
 
   // Now register the multimap again
-  define_multimap<std::multimap<std::string, std::complex<double>>>("ComplexMultimap");
+  define_multimap<std::string, std::complex<double>>("ComplexMultimap");
   code = R"(multimap = Std::ComplexMultimap.new)";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(multimap.class_of()));
 
   // And again in the module
-  define_multimap<std::multimap<std::string, std::complex<double>>>("ComplexMultimap2");
+  define_multimap<std::string, std::complex<double>>("ComplexMultimap2");
   code = R"(multimap = Std::ComplexMultimap2.new)";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(multimap.class_of()));
@@ -505,7 +505,7 @@ namespace
 
 TESTCASE(DefaultValue)
 {
-  define_multimap<std::multimap<std::string, std::string>>("StringMultimap");
+  define_multimap<std::string, std::string>("StringMultimap");
   define_global_function("default_multimap", &defaultMultimap, Arg("strings") = std::multimap<std::string, std::string>{ {"one", "value 1"}, {"two", "value 2"}, {"three", "value 3"} });
 
   Module m = define_module("Testing");

--- a/test/test_Stl_Pair.cpp
+++ b/test/test_Stl_Pair.cpp
@@ -23,7 +23,7 @@ TESTCASE(CreatePair)
 {
   Module m = define_module("Testing");
 
-  Class c = define_pair<std::pair<int32_t, std::optional<std::string>>>("IntStringPair");
+  Class c = define_pair<int32_t, std::optional<std::string>>("IntStringPair");
 
   Object pair = c.call("new", 0, nullptr);
 
@@ -50,7 +50,7 @@ TESTCASE(CreatePairConst)
 {
   Module m = define_module("Testing");
 
-  Class c = define_pair<std::pair<const std::string, const std::string>>("ConstStringPair");
+  Class c = define_pair<const std::string, const std::string>("ConstStringPair");
   Object pair = c.call("new", "pair1", "pair2");
 
   Object result = pair.call("first");
@@ -130,14 +130,14 @@ TESTCASE(AutoRegister)
   ASSERT_EQUAL(3.2, detail::From_Ruby<double>().convert(result));
 
   // Now register the pair again
-  define_pair<std::pair<std::string, double>>("SomePair");
-  std::string code = R"(pair = SomePair.new('string', 2.0))";
+  define_pair<std::string, double>("SomePair");
+  std::string code = R"(pair = Std::SomePair.new('string', 2.0))";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(pair.class_of()));
 
   // And again in the module
-  define_pair_under<std::pair<std::string, double>>(m, "SomePair2");
-  code = R"(pair = Testing::SomePair2.new('string', 3.0))";
+  define_pair<std::string, double>("SomePair2");
+  code = R"(pair = Std::SomePair2.new('string', 3.0))";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(pair.class_of()));
 }
@@ -156,7 +156,7 @@ TESTCASE(ReferenceReturned)
     define_constructor(Constructor<SomeStruct>()).
     define_attr("value", &SomeStruct::value);
 
-  define_pair<std::pair<char, SomeStruct>>("CharSomeStructPair");
+  define_pair<char, SomeStruct>("CharSomeStructPair");
 
   std::pair<char, SomeStruct> aPair;
   aPair.first = 'a';

--- a/test/test_Stl_Set.cpp
+++ b/test/test_Stl_Set.cpp
@@ -35,7 +35,7 @@ namespace
 TESTCASE(Size)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(s = Std::StringSet.new
                         s.size)";
@@ -62,7 +62,7 @@ TESTCASE(Size)
 TESTCASE(Add)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set = Std::StringSet.new
                         set << "one" << "two" << "two" << "three"
@@ -84,7 +84,7 @@ TESTCASE(Add)
 TESTCASE(WrongType)
 {
   Module m = define_module("Testing");
-  Class c = define_set<std::set<std::string>>("StringSet");
+  Class c = define_set<std::string>("StringSet");
 
   std::string code = R"(set = Std::StringSet.new
                         set << 1
@@ -100,7 +100,7 @@ TESTCASE(Empty)
 {
   Module m = define_module("Testing");
 
-  Class c = define_set<std::set<std::int32_t>>("IntSet");
+  Class c = define_set<std::int32_t>("IntSet");
 
   std::string code = R"(set = Std::StringSet.new
                         set.size)";
@@ -117,7 +117,7 @@ TESTCASE(Empty)
 TESTCASE(ToString)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set = Std::StringSet.new
                         set.insert("one")
@@ -131,7 +131,7 @@ TESTCASE(ToString)
 TESTCASE(Include)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set = Std::StringSet.new
                         set << "one" << "two" << "two" << "three"
@@ -145,7 +145,7 @@ TESTCASE(Modify)
 {
   Module m = define_module("Testing");
 
-  Class c = define_set<std::set<int>>("Int64Set");
+  Class c = define_set<int>("Int64Set");
   Object set = c.call("new");
 
   Object result = set.call("insert", 11);
@@ -171,7 +171,7 @@ TESTCASE(Modify)
 TESTCASE(Clone)
 {
   Module m = define_module("Testing");
-  Class c = define_set<std::set<double>>("DoubleSet");
+  Class c = define_set<double>("DoubleSet");
 
   std::string code = R"(set = Std::DoubleSet.new
                         set << 11.1 << 22.2)";
@@ -211,7 +211,7 @@ TESTCASE(NotPrintable)
   define_class<NotPrintable>("NotPrintable").
     define_constructor(Constructor<NotPrintable, uint32_t>());
 
-  Class c = define_set<std::set<NotPrintable>>("NotPrintableSet");
+  Class c = define_set<NotPrintable>("NotPrintableSet");
 
   Object set = c.call("new");
   set.call("insert", NotPrintable(1));
@@ -254,13 +254,13 @@ TESTCASE(AutoRegisterReturn)
   ASSERT_EQUAL(Qtrue, result.value());
 
   // Now register this same set
-  define_set<std::set<float>>("FloatSet");
+  define_set<float>("FloatSet");
   code = R"(set = Std::FloatSet.new)";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(set.class_of()));
 
   // Now register it again in the module
-  define_set<std::set<float>>("FloatSet2");
+  define_set<float>("FloatSet2");
   code = R"(set = Std::FloatSet2.new)";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(set.class_of()));
@@ -293,7 +293,7 @@ namespace
 
 TESTCASE(DefaultValue)
 {
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
   define_global_function("default_set", &defaultSet, Arg("strings") = std::set<std::string> { "one", "two", "three" });
 
   Module m = define_module("Testing");
@@ -309,7 +309,7 @@ TESTCASE(DefaultValue)
 TESTCASE(Equal)
 {
   Module m = define_module("Testing");
-  Class c = define_set<std::set<int>>("IntSet");
+  Class c = define_set<int>("IntSet");
 
   std::string code = R"(set1 = Std::IntSet.new
                         set1 << 4 << 5 << 6
@@ -325,7 +325,7 @@ TESTCASE(Equal)
   define_class<NotPrintable>("NotPrintable").
     define_constructor(Constructor<NotPrintable, uint32_t>());
 
-  define_set<std::set<NotPrintable>>("NotPrintableSet");
+  define_set<NotPrintable>("NotPrintableSet");
 
   code = R"(set1 = Std::NotPrintableSet.new
             set2 = Std::NotPrintableSet.new
@@ -339,7 +339,7 @@ TESTCASE(ToArray)
 {
   Module m = define_module("Testing");
   
-  Class c = define_set<std::set<std::string>>("StringSet").
+  Class c = define_set<std::string>("StringSet").
     define_constructor(Constructor<std::set<std::string>>());
 
   std::string code = R"(set = Std::StringSet.new
@@ -544,7 +544,7 @@ TESTCASE(Returns)
 TESTCASE(Iterate)
 {
   Module m = define_module("Testing");
-  Class c = define_set<std::set<double>>("DoubleSet");
+  Class c = define_set<double>("DoubleSet");
 
   std::string code = R"(set = Std::DoubleSet.new
                         set << 5.0 << 6.0 << 7.0
@@ -691,7 +691,7 @@ TESTCASE(MyClass2PointerSet)
 TESTCASE(Intersect)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set1 = Std::StringSet.new
                         set1 << "one" << "two" << "two" << "three"
@@ -712,7 +712,7 @@ TESTCASE(Intersect)
 TESTCASE(Union)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set1 = Std::StringSet.new
                         set1 << "one" << "two" << "two" << "three"
@@ -733,7 +733,7 @@ TESTCASE(Union)
 TESTCASE(Difference)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set1 = Std::StringSet.new
                         set1 << "one" << "two" << "two" << "three"
@@ -754,7 +754,7 @@ TESTCASE(Difference)
 TESTCASE(Exclusive)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set1 = Std::StringSet.new
                         set1 << "one" << "two" << "three"
@@ -775,7 +775,7 @@ TESTCASE(Exclusive)
 TESTCASE(Superset)
 {
   Module m = define_module("Testing");
-  define_set<std::set<std::string>>("StringSet");
+  define_set<std::string>("StringSet");
 
   std::string code = R"(set1 = Std::StringSet.new
                         set1 << "one" << "two" << "three"

--- a/test/test_Stl_SharedPtr.cpp
+++ b/test/test_Stl_SharedPtr.cpp
@@ -415,7 +415,7 @@ TESTCASE(CreatePointerToInt)
   Module m = define_module("CreatePointerToInt").
     define_module_function("get_pointer_value", &getPointerValue);
 
-  define_shared_ptr<std::shared_ptr<int>>("SharedPtrInt");
+  define_shared_ptr<int>("SharedPtrInt");
 
   std::string code = R"(buffer = Rice::Buffer≺int≻.new(45)
                         ptr = Std::SharedPtrInt.new(buffer)
@@ -430,7 +430,7 @@ TESTCASE(UpdatePointerToInt)
   Module m = define_module("UpdatePointerToInt").
     define_module_function("update_pointer_value", &updatePointerValue);
 
-  define_shared_ptr<std::shared_ptr<int>>();
+  define_shared_ptr<int>();
 
   std::string code = R"(buffer = Rice::Buffer≺int≻.new(45)
                         ptr = Std::SharedPtr≺int≻.new(buffer)

--- a/test/test_Stl_Unordered_Map.cpp
+++ b/test/test_Stl_Unordered_Map.cpp
@@ -47,7 +47,7 @@ TESTCASE(StringUnorderedMap)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, std::string>>("StringUnorderedMap");
+  Class c = define_unordered_map<std::string, std::string>("StringUnorderedMap");
 
   Object unordered_map = m.module_eval("$unordered_map = Std::StringUnorderedMap.new");
   Object result = unordered_map.call("size");
@@ -66,7 +66,7 @@ TESTCASE(WrongType)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, std::string>>("StringUnorderedMap");
+  Class c = define_unordered_map<std::string, std::string>("StringUnorderedMap");
   Object unordered_map = m.module_eval("$unordered_map = Std::StringUnorderedMap.new");
 
   ASSERT_EXCEPTION_CHECK(
@@ -84,7 +84,7 @@ TESTCASE(Empty)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, std::int32_t>>("IntUnorderedMap");
+  Class c = define_unordered_map<std::string, std::int32_t>("IntUnorderedMap");
   Data_Object<std::unordered_map<std::string, std::int32_t>> unordered_map = c.call("new");
 
   Object result = unordered_map.call("size");
@@ -98,7 +98,7 @@ TESTCASE(Include)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, std::int32_t>>("IntUnorderedMap");
+  Class c = define_unordered_map<std::string, std::int32_t>("IntUnorderedMap");
   Data_Object<std::unordered_map<std::string, std::int32_t>> unordered_map = c.call("new");
   unordered_map.call("[]=", "one", 1);
   unordered_map.call("[]=", "two", 2);
@@ -117,7 +117,7 @@ TESTCASE(Value)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, std::int32_t>>("IntUnorderedMap");
+  Class c = define_unordered_map<std::string, std::int32_t>("IntUnorderedMap");
   Data_Object<std::unordered_map<std::string, std::int32_t>> unordered_map = c.call("new");
   unordered_map.call("[]=", "one", 1);
   unordered_map.call("[]=", "two", 2);
@@ -133,7 +133,7 @@ TESTCASE(ToString)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, std::int32_t>>("IntUnorderedMap");
+  Class c = define_unordered_map<std::string, std::int32_t>("IntUnorderedMap");
   Data_Object<std::unordered_map<std::string, std::int32_t>> unordered_map = c.call("new");
   unordered_map.call("[]=", "one", 1);
   unordered_map.call("[]=", "two", 2);
@@ -151,7 +151,7 @@ TESTCASE(Update)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, std::string>>("StringUnorderedMap");
+  Class c = define_unordered_map<std::string, std::string>("StringUnorderedMap");
   Data_Object<std::unordered_map<std::string, std::string>> unordered_map = c.call("new");
   unordered_map.call("[]=", "one", "original 1");
   unordered_map.call("[]=", "two", "original 2");
@@ -173,7 +173,7 @@ TESTCASE(Modify)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, int64_t>>("Int64UnorderedMap");
+  Class c = define_unordered_map<std::string, int64_t>("Int64UnorderedMap");
   Data_Object<std::unordered_map<std::string, std::int64_t>> unordered_map = c.call("new");
 
   Object result = unordered_map.call("[]=", "one", 3232323232);
@@ -192,7 +192,7 @@ TESTCASE(KeysAndValues)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, int32_t>>("Int32UnorderedMap");
+  Class c = define_unordered_map<std::string, int32_t>("Int32UnorderedMap");
   Data_Object<std::unordered_map<std::string, std::int32_t>> unordered_map = c.call("new");
 
   unordered_map.call("[]=", "one", 1);
@@ -220,7 +220,7 @@ TESTCASE(Copy)
 {
   Module m = define_module("Testing");
 
-  Class c = define_unordered_map<std::unordered_map<std::string, double>>("DoubleUnorderedMap");
+  Class c = define_unordered_map<std::string, double>("DoubleUnorderedMap");
   Object object = c.call("new");
 
   object.call("[]=", "one", 11.1);
@@ -241,7 +241,7 @@ TESTCASE(Copy)
 TESTCASE(Iterate)
 {
   Module m = define_module("Testing");
-  Class c = define_unordered_map<std::unordered_map<std::string, int>>("IntUnorderedMap");
+  Class c = define_unordered_map<std::string, int>("IntUnorderedMap");
 
   std::string code = R"(unordered_map = Std::IntUnorderedMap.new
                         unordered_map["five"] = 5
@@ -265,7 +265,7 @@ TESTCASE(Iterate)
 TESTCASE(ToEnum)
 {
   Module m = define_module("Testing");
-  Class c = define_unordered_map<std::unordered_map<std::string, int>>("IntUnorderedMap");
+  Class c = define_unordered_map<std::string, int>("IntUnorderedMap");
 
   std::string code = R"(unordered_map = Std::IntUnorderedMap.new
                         unordered_map["five"] = 5
@@ -290,7 +290,7 @@ TESTCASE(ToEnum)
 TESTCASE(ToEnumSize)
 {
   Module m = define_module("TestingModule");
-  Class c = define_unordered_map<std::unordered_map<std::string, int>>("IntUnorderedMap");
+  Class c = define_unordered_map<std::string, int>("IntUnorderedMap");
 
   std::string code = R"(map = Std::IntUnorderedMap.new
                         map["five"] = 5
@@ -327,7 +327,7 @@ TESTCASE(NotComparable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_unordered_map<std::unordered_map<std::string, NotComparable>>("NotComparableUnorderedMap");
+  Class c = define_unordered_map<std::string, NotComparable>("NotComparableUnorderedMap");
 
   Data_Object<std::unordered_map<std::string, NotComparable>> unordered_map = c.call("new");
   unordered_map.call("[]=", "one", NotComparable(1));
@@ -346,7 +346,7 @@ TESTCASE(NotPrintable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_unordered_map<std::unordered_map<std::string, NotComparable>>("NotComparableUnorderedMap");
+  Class c = define_unordered_map<std::string, NotComparable>("NotComparableUnorderedMap");
 
   Data_Object<std::unordered_map<std::string, NotComparable>> unordered_map = c.call("new");
   unordered_map.call("[]=", "one", NotComparable(1));
@@ -387,7 +387,7 @@ TESTCASE(Comparable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_unordered_map<std::unordered_map<std::string, Comparable>>("ComparableUnorderedMap");
+  Class c = define_unordered_map<std::string, Comparable>("ComparableUnorderedMap");
 
   Data_Object<std::unordered_map<std::string, Comparable>> unordered_map = c.call("new");
   
@@ -404,7 +404,7 @@ TESTCASE(Printable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_unordered_map<std::unordered_map<std::string, Comparable>>("ComparableUnorderedMap");
+  Class c = define_unordered_map<std::string, Comparable>("ComparableUnorderedMap");
 
   Data_Object<std::unordered_map<std::string, Comparable>> unordered_map = c.call("new");
   unordered_map.call("[]=", "one", Comparable(1));
@@ -454,7 +454,7 @@ TESTCASE(AutoRegisterReturn)
   ASSERT_EQUAL(Qtrue, result.value());
 
   // Now register the unordered_map again
-  define_unordered_map<std::unordered_map<std::string, std::complex<double>>>("ComplexUnorderedMap");
+  define_unordered_map<std::string, std::complex<double>>("ComplexUnorderedMap");
   code = R"(unordered_map = Std::ComplexUnorderedMap.new)";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(unordered_map.class_of()));
@@ -492,7 +492,7 @@ namespace
 
 TESTCASE(DefaultValue)
 {
-  define_unordered_map<std::unordered_map<std::string, std::string>>("StringUnorderedMap");
+  define_unordered_map<std::string, std::string>("StringUnorderedMap");
   define_global_function("default_unordered_map", &defaultUnorderedMap, Arg("strings") = std::unordered_map<std::string, std::string>{ {"one", "value 1"}, {"two", "value 2"}, {"three", "value 3"} });
 
   Module m = define_module("Testing");

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -45,7 +45,7 @@ TESTCASE(StringVector)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::string>>("StringVector");
+  Class c = define_vector<std::string>("StringVector");
 
   Object vec = m.module_eval("$vector = Std::StringVector.new");
   Object result = vec.call("size");
@@ -70,7 +70,7 @@ TESTCASE(WrongElementType)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::string>>("StringVector");
+  Class c = define_vector<std::string>("StringVector");
 
   Object vec = m.module_eval("$vector = Std::StringVector.new");
   ASSERT_EXCEPTION_CHECK(
@@ -83,7 +83,7 @@ TESTCASE(Empty)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::int32_t>>("IntVector");
+  Class c = define_vector<std::int32_t>("IntVector");
   Object vec = c.call("new");
 
   Object result = vec.call("size");
@@ -101,7 +101,7 @@ TESTCASE(Empty)
 
 TESTCASE(BoolVector)
 {
-  Class boolVecClass = define_vector<std::vector<bool>>("BoolVector");
+  Class boolVecClass = define_vector<bool>("BoolVector");
 
   Object vec = boolVecClass.call("new");
   vec.call("resize", 3, true);
@@ -142,7 +142,7 @@ TESTCASE(Indexing)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::int32_t>>("IntVector");
+  Class c = define_vector<std::int32_t>("IntVector");
   Object vec = c.call("new");
   vec.call("push", 0);
   vec.call("push", 1);
@@ -183,7 +183,7 @@ TESTCASE(Slice)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::int32_t>>("IntVector");
+  Class c = define_vector<std::int32_t>("IntVector");
   Object vec = c.call("new");
   vec.call("push", 7);
   vec.call("push", 8);
@@ -219,7 +219,7 @@ TESTCASE(Sizing)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::int32_t>>("IntVector");
+  Class c = define_vector<std::int32_t>("IntVector");
   Object vec = c.call("new");
   vec.call("resize", 10);
 
@@ -236,7 +236,7 @@ TESTCASE(ToString)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::int32_t>>("IntVector");
+  Class c = define_vector<std::int32_t>("IntVector");
   Object vec = c.call("new");
   vec.call("resize", 3);
 
@@ -253,7 +253,7 @@ TESTCASE(Update)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<std::string>>("StringVector");
+  Class c = define_vector<std::string>("StringVector");
   Object vec = c.call("new");
   vec.call("push", "original 1");
   vec.call("push", "original 2");
@@ -277,7 +277,7 @@ TESTCASE(Modify)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<int64_t>>("Int64Vector");
+  Class c = define_vector<int64_t>("Int64Vector");
   Object vec = c.call("new");
 
   Object result = vec.call("push", 11);
@@ -321,7 +321,7 @@ TESTCASE(Copy)
 {
   Module m = define_module("Testing");
 
-  Class c = define_vector<std::vector<double>>("DoubleVector");
+  Class c = define_vector<double>("DoubleVector");
   Object object = c.call("new");
 
   object.call("push", 11.1);
@@ -357,7 +357,7 @@ TESTCASE(NotComparable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_vector<std::vector<NotComparable>>("NotComparableVector");
+  Class c = define_vector<NotComparable>("NotComparableVector");
 
   Object vec = c.call("new");
   vec.call("push", NotComparable(1));
@@ -382,7 +382,7 @@ TESTCASE(NotDefaultConstructable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
     
-  Class c = define_vector<std::vector<NotComparable>>("NotComparableVector");
+  Class c = define_vector<NotComparable>("NotComparableVector");
   Object vec = c.call("new");
 
   Object result = vec.call("resize", 10);
@@ -397,7 +397,7 @@ TESTCASE(NotPrintable)
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
 
-  Class c = define_vector<std::vector<NotComparable>>("NotComparableVector");
+  Class c = define_vector<NotComparable>("NotComparableVector");
 
   Object vec = c.call("new");
   vec.call("push", NotComparable(1));
@@ -437,7 +437,7 @@ TESTCASE(Comparable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_vector<std::vector<Comparable>>("ComparableVector");
+  Class c = define_vector<Comparable>("ComparableVector");
 
   Object vec = c.call("new");
   
@@ -487,7 +487,7 @@ TESTCASE(ComparableButNotBool)
   define_class<ComparableButNotBool>("IsComparableButNotBool").
     define_constructor(Constructor<ComparableButNotBool, uint32_t>());
 
-  Class c = define_vector<std::vector<ComparableButNotBool>>("ComparableButNotBoolVector");
+  Class c = define_vector<ComparableButNotBool>("ComparableButNotBoolVector");
 
   Object vec = c.call("new");
   vec.call("push", ComparableButNotBool(1));
@@ -512,7 +512,7 @@ TESTCASE(DefaultConstructable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_vector<std::vector<Comparable>>("ComparableVector");
+  Class c = define_vector<Comparable>("ComparableVector");
   Object vec = c.call("new");
 
   Object result = vec.call("resize", 10);
@@ -527,7 +527,7 @@ TESTCASE(Printable)
   define_class<Comparable>("IsComparable").
     define_constructor(Constructor<Comparable, uint32_t>());
 
-  Class c = define_vector<std::vector<Comparable>>("ComparableVector");
+  Class c = define_vector<Comparable>("ComparableVector");
 
   Object vec = c.call("new");
   vec.call("push", Comparable(1));
@@ -575,7 +575,7 @@ TESTCASE(AutoRegisterReturn)
   ASSERT_EQUAL(Qtrue, result.value());
 
   // Now register this same vector
-  define_vector<std::vector<std::complex<double>>>("ComplexVector");
+  define_vector<std::complex<double>>("ComplexVector");
   code = R"(vector = Std::ComplexVector.new)";
   result = m.module_eval(code);
   ASSERT(result.is_instance_of(vec.class_of()));
@@ -612,7 +612,7 @@ namespace
 
 TESTCASE(DefaultValue)
 {
-  define_vector<std::vector<std::string>>("StringVector");
+  define_vector<std::string>("StringVector");
   define_global_function("default_vector", &defaultVector, Arg("strings") = std::vector<std::string> { "one", "two", "three" });
 
   Module m = define_module("Testing");
@@ -631,7 +631,7 @@ TESTCASE(ToArray)
 {
   Module m = define_module("Testing");
   
-  Class c = define_vector<std::vector<std::string>>("StringVector").
+  Class c = define_vector<std::string>("StringVector").
     define_constructor(Constructor<std::vector<std::string>>());
 
   std::string code = R"(vector = Std::StringVector.new
@@ -842,7 +842,7 @@ TESTCASE(Returns)
 TESTCASE(Iterate)
 {
   Module m = define_module("Testing");
-  Class c = define_vector<std::vector<double>>("DoubleVector");
+  Class c = define_vector<double>("DoubleVector");
 
   std::string code = R"(vector = Std::DoubleVector.new
                         vector << 5.0 << 6.0 << 7.0
@@ -1006,7 +1006,7 @@ namespace
 
 TESTCASE(TypeCheck)
 {
-  define_vector<std::vector<int>>("Vector≺int≻");
+  define_vector<int>("Vector≺int≻");
 
   Module m(anonymous_module());
   m.define_module_function("check_value", &typeCheckValue).


### PR DESCRIPTION
A large changeset that updates define methods to be more like the STL has methods like `make_shared<T>`, while Rice was using `define_shared_ptr<std::shared_ptr<T>>`. Rice has now switched to `define_shared_ptr<T>`. Note this is not a backwards compatible change, but is fairly easy to adopt.