### PR TITLE
Revamp Keyword Arguments and Default Values

### DIFF
--- a/rice/Arg.hpp
+++ b/rice/Arg.hpp
@@ -55,7 +55,7 @@ namespace Rice
     /*! \return the type saved to this Arg
      */
     template<typename Arg_Type>
-    Arg_Type& defaultValue();
+    Arg_Type defaultValue();
 
     //! Tell the receiving object to keep this argument alive
     //! until the receiving object is freed.

--- a/rice/Arg.ipp
+++ b/rice/Arg.ipp
@@ -21,9 +21,9 @@ namespace Rice
   /*! \return the type saved to this Arg
     */
   template<typename Arg_Type>
-  inline Arg_Type& Arg::defaultValue()
+  inline Arg_Type Arg::defaultValue()
   {
-    return std::any_cast<Arg_Type&>(this->defaultValue_);
+    return std::any_cast<Arg_Type>(this->defaultValue_);
   }
 
   inline Arg& Arg::keepAlive()

--- a/rice/Data_Object.ipp
+++ b/rice/Data_Object.ipp
@@ -342,35 +342,16 @@ namespace Rice::detail
 
     T convert(VALUE value)
     {
-      // This expression checks to see if T has an explicit copy constructor
-      // If it does then we have to call it directly. Not sure if this end ups
-      // with an extra copy or not?
-      // 
-      // std::is_constructible_v<T, T> && !std::is_convertible_v<T, T>
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
+      using Intrinsic_T = intrinsic_type<T>;
+      Intrinsic_T* instance = detail::unwrap<Intrinsic_T>(value, Data_Type<Intrinsic_T>::ruby_data_type(), this->arg_ && this->arg_->isOwner());
+
+      if constexpr (std::is_constructible_v<T, T> && !std::is_convertible_v<T, T>)
       {
-        if constexpr (std::is_constructible_v<T, T> && !std::is_convertible_v<T, T>)
-        {
-          return T(this->arg_->template defaultValue<T>());
-        }
-        else
-        {
-          return this->arg_->template defaultValue<T>();
-        }
+        return T(*instance);
       }
       else
       {
-        using Intrinsic_T = intrinsic_type<T>;
-        Intrinsic_T* instance = detail::unwrap<Intrinsic_T>(value, Data_Type<Intrinsic_T>::ruby_data_type(), this->arg_ && this->arg_->isOwner());
-
-        if constexpr (std::is_constructible_v<T, T> && !std::is_convertible_v<T, T>)
-        {
-          return T(*instance);
-        }
-        else
-        {
-          return *instance;
-        }
+        return *instance;
       }
     }
 
@@ -414,14 +395,7 @@ namespace Rice::detail
     {
       using Intrinsic_T = intrinsic_type<T>;
 
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->template defaultValue<Intrinsic_T>();
-      }
-      else
-      {
-        return *detail::unwrap<Intrinsic_T>(value, Data_Type<Intrinsic_T>::ruby_data_type(), this->arg_ && this->arg_->isOwner()); 
-      }
+      return *detail::unwrap<Intrinsic_T>(value, Data_Type<Intrinsic_T>::ruby_data_type(), this->arg_ && this->arg_->isOwner()); 
     }
 
   private:
@@ -464,15 +438,8 @@ namespace Rice::detail
     {
       using Intrinsic_T = intrinsic_type<T>;
 
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return std::move(this->arg_->template defaultValue<Intrinsic_T>());
-      }
-      else
-      {
-        Intrinsic_T* object = detail::unwrap<Intrinsic_T>(value, Data_Type<Intrinsic_T>::ruby_data_type(), this->arg_ && this->arg_->isOwner());
-        return std::move(*object);
-      }
+      Intrinsic_T* object = detail::unwrap<Intrinsic_T>(value, Data_Type<Intrinsic_T>::ruby_data_type(), this->arg_ && this->arg_->isOwner());
+      return std::move(*object);
     }
 
   private:

--- a/rice/detail/MethodInfo.hpp
+++ b/rice/detail/MethodInfo.hpp
@@ -14,12 +14,6 @@ namespace Rice
     MethodInfo(size_t argCount, const Arg_Ts&...args);
 
     /**
-      * Get the rb_scan_args format string for this
-      * list of arguments.
-      */
-    std::string formatString();
-
-    /**
       * Add a defined Arg to this list of Arguments
       */
     void addArg(const Arg& arg);
@@ -34,9 +28,7 @@ namespace Rice
       */
     Arg* arg(std::string name);
 
-    int requiredArgCount();
-    int optionalArgCount();
-    void verifyArgCount(size_t argc);
+    int argCount();
 
     // Iterator support
     std::vector<Arg>::iterator begin();

--- a/rice/detail/MethodInfo.ipp
+++ b/rice/detail/MethodInfo.ipp
@@ -42,78 +42,9 @@ namespace Rice
     this->args_.push_back(arg);
   }
 
-  inline int MethodInfo::requiredArgCount()
+  inline int MethodInfo::argCount()
   {
-    int result = 0;
-
-    for (const Arg& arg : this->args_)
-    {
-      if (!arg.hasDefaultValue())
-      {
-        result++;
-      }
-    }
-
-    return result;
-  }
-
-  inline int MethodInfo::optionalArgCount()
-  {
-    int result = 0;
-
-    for (const Arg& arg : this->args_)
-    {
-      if (arg.hasDefaultValue())
-      {
-        result++;
-      }
-    }
-
-    return result;
-  }
-
-  inline void MethodInfo::verifyArgCount(size_t argc)
-  {
-    int requiredArgCount = this->requiredArgCount();
-    int optionalArgCount = this->optionalArgCount();
-
-    if (argc < requiredArgCount || argc > requiredArgCount + optionalArgCount)
-    {
-      std::string message;
-
-      if (optionalArgCount > 0)
-      {
-        message = "wrong number of arguments (given " +
-          std::to_string(argc) + ", expected " +
-          std::to_string(requiredArgCount) + ".." + std::to_string(requiredArgCount + optionalArgCount) + ")";
-      }
-      else
-      {
-        message = "wrong number of arguments (given " +
-          std::to_string(argc) + ", expected " + std::to_string(requiredArgCount) + ")";
-      }
-      throw std::invalid_argument(message);
-    }
-  }
-
-  inline std::string MethodInfo::formatString()
-  {
-    size_t required = 0;
-    size_t optional = 0;
-
-    for (const Arg& arg : this->args_)
-    {
-      if (arg.hasDefaultValue())
-      {
-        optional++;
-      }
-      else
-      {
-        required++;
-      }
-    }
-
-    return std::to_string(required) + std::to_string(optional);
+    return this->args_.size();
   }
 
   inline Arg* MethodInfo::arg(size_t pos)

--- a/rice/detail/NativeFunction.hpp
+++ b/rice/detail/NativeFunction.hpp
@@ -75,10 +75,10 @@ namespace Rice::detail
 
   private:
     template<int I>
-    Convertible matchParameter(std::vector<VALUE>& values, size_t index);
+    Convertible matchParameter(std::vector<std::optional<VALUE>>& value);
 
     template<std::size_t...I>
-    Convertible matchParameters(std::vector<VALUE>& values, std::index_sequence<I...>& indices);
+    Convertible matchParameters(std::vector<std::optional<VALUE>>& values, std::index_sequence<I...>& indices);
 
     template<std::size_t...I>
     std::vector<std::string> argTypeNames(std::ostringstream& stream, std::index_sequence<I...>& indices);
@@ -94,14 +94,14 @@ namespace Rice::detail
     To_Ruby<To_Ruby_T> createToRuby();
       
     // Convert Ruby argv pointer to Ruby values
-    std::vector<VALUE> getRubyValues(int argc, const VALUE* argv, bool validate);
+    std::vector<std::optional<VALUE>> getRubyValues(int argc, const VALUE* argv, bool validate);
 
     template<typename Arg_T, int I>
-    Arg_T getNativeValue(std::vector<VALUE>& values);
+    Arg_T getNativeValue(std::vector<std::optional<VALUE>>& values);
 
     // Convert Ruby values to C++ values
     template<typename std::size_t...I>
-    Arg_Ts getNativeValues(std::vector<VALUE>& values, std::index_sequence<I...>& indices);
+    Arg_Ts getNativeValues(std::vector<std::optional<VALUE>>& values, std::index_sequence<I...>& indices);
 
     // Figure out what self is
     Receiver_T getReceiver(VALUE self);
@@ -110,7 +110,7 @@ namespace Rice::detail
     [[noreturn]] void noWrapper(const VALUE klass, const std::string& wrapper);
 
     // Do we need to keep alive any arguments?
-    void checkKeepAlive(VALUE self, VALUE returnValue, std::vector<VALUE>& rubyValues);
+    void checkKeepAlive(VALUE self, VALUE returnValue, std::vector<std::optional<VALUE>>& rubyValues);
 
     // Call the underlying C++ function
     VALUE invokeNativeFunction(Arg_Ts&& nativeArgs);

--- a/rice/detail/from_ruby.ipp
+++ b/rice/detail/from_ruby.ipp
@@ -90,14 +90,7 @@ namespace Rice::detail
       {
         case RUBY_T_NIL:
         {
-          if (arg && arg->hasDefaultValue())
-          {
-            return arg->defaultValue<T*>();
-          }
-          else
-          {
-            return nullptr;
-          }
+          return nullptr;
         }
         case RUBY_T_DATA:
         {
@@ -157,14 +150,7 @@ namespace Rice::detail
       {
         case RUBY_T_NIL:
         {
-          if (arg && arg->hasDefaultValue())
-          {
-            return arg->defaultValue<T**>();
-          }
-          else
-          {
-            return nullptr;
-          }
+          return nullptr;
         }
         case RUBY_T_DATA:
         {
@@ -208,14 +194,7 @@ namespace Rice::detail
 
     bool convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<bool>();
-      }
-      else
-      {
-        return FromRubyFundamental<bool>::convert(value);
-      }
+      return FromRubyFundamental<bool>::convert(value);
     }
 
   private:
@@ -248,11 +227,7 @@ namespace Rice::detail
 
     bool& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<bool>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -311,14 +286,7 @@ namespace Rice::detail
 
     char convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<char>();
-      }
-      else
-      {
-        return FromRubyFundamental<char>::convert(value);
-      }
+      return FromRubyFundamental<char>::convert(value);
     }
 
   private:
@@ -351,11 +319,7 @@ namespace Rice::detail
 
     char& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<char>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -478,14 +442,7 @@ namespace Rice::detail
 
     unsigned char convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned char>();
-      }
-      else
-      {
-        return FromRubyFundamental<unsigned char>::convert(value);
-      }
+      return FromRubyFundamental<unsigned char>::convert(value);
     }
 
   private:
@@ -518,11 +475,7 @@ namespace Rice::detail
 
     unsigned char& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned char>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -609,14 +562,7 @@ namespace Rice::detail
 
     signed char convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<signed char>();
-      }
-      else
-      {
-        return FromRubyFundamental<signed char>::convert(value);
-      }
+      return FromRubyFundamental<signed char>::convert(value);
     }
 
   private:
@@ -693,14 +639,7 @@ namespace Rice::detail
 
     double convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<double>();
-      }
-      else
-      {
-        return FromRubyFundamental<double>::convert(value);
-      }
+      return FromRubyFundamental<double>::convert(value);
     }
 
   private:
@@ -733,11 +672,7 @@ namespace Rice::detail
 
     double& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<double>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -824,14 +759,7 @@ namespace Rice::detail
 
     float convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<float>();
-      }
-      else
-      {
-        return FromRubyFundamental<float>::convert(value);
-      }
+      return FromRubyFundamental<float>::convert(value);
     }
 
   private:
@@ -864,11 +792,7 @@ namespace Rice::detail
 
     float& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<float>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -966,14 +890,7 @@ namespace Rice::detail
 
     int convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<int>();
-      }
-      else
-      {
-        return FromRubyFundamental<int>::convert(value);
-      }
+      return FromRubyFundamental<int>::convert(value);
     }
   
   private:
@@ -1006,11 +923,7 @@ namespace Rice::detail
 
     int& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<int>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -1097,14 +1010,7 @@ namespace Rice::detail
 
     unsigned int convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned int>();
-      }
-      else
-      {
-        return FromRubyFundamental<unsigned int>::convert(value);
-      }
+      return FromRubyFundamental<unsigned int>::convert(value);
     }
 
   private:
@@ -1137,11 +1043,7 @@ namespace Rice::detail
 
     unsigned int& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned int>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -1228,14 +1130,7 @@ namespace Rice::detail
 
     long convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<long>();
-      }
-      else
-      {
-        return FromRubyFundamental<long>::convert(value);
-      }
+      return FromRubyFundamental<long>::convert(value);
     }
   
   private:
@@ -1268,11 +1163,7 @@ namespace Rice::detail
 
     long& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<long>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -1363,10 +1254,6 @@ namespace Rice::detail
       {
         return (unsigned long)value;
       }
-      else if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned long>();
-      }
       else
       {
         return FromRubyFundamental<unsigned long>::convert(value);
@@ -1403,11 +1290,7 @@ namespace Rice::detail
 
     unsigned long& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned long>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -1498,10 +1381,6 @@ namespace Rice::detail
       {
         return value;
       }
-      else if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned long long>();
-      }
       else
       {
         return FromRubyFundamental<unsigned long long>::convert(value);
@@ -1538,11 +1417,7 @@ namespace Rice::detail
 
     unsigned long long& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned long long>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -1629,14 +1504,7 @@ namespace Rice::detail
 
     long long convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<long long>();
-      }
-      else
-      {
-        return FromRubyFundamental<long long>::convert(value);
-      }
+      return FromRubyFundamental<long long>::convert(value);
     }
   
   private:
@@ -1669,11 +1537,7 @@ namespace Rice::detail
 
     long long& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<long long>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -1760,14 +1624,7 @@ namespace Rice::detail
 
     short convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<short>();
-      }
-      else
-      {
-        return FromRubyFundamental<short>::convert(value);
-      }
+      return FromRubyFundamental<short>::convert(value);
     }
 
   private:
@@ -1800,11 +1657,7 @@ namespace Rice::detail
 
     short& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<short>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();
@@ -1890,14 +1743,7 @@ namespace Rice::detail
 
     unsigned short convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned short>();
-      }
-      else
-      {
-        return FromRubyFundamental<unsigned short>::convert(value);
-      }
+      return FromRubyFundamental<unsigned short>::convert(value);
     }
   
   private:
@@ -1930,11 +1776,7 @@ namespace Rice::detail
 
     unsigned short& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<unsigned short>();
-      }
-      else if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
+      if (rb_type(value) == RUBY_T_DATA && Data_Type<Buffer_T>::is_descendant(value))
       {
         Buffer_T* buffer = unwrap<Buffer_T>(value, Data_Type<Buffer_T>::ruby_data_type(), false);
         return buffer->reference();

--- a/rice/stl/map.ipp
+++ b/rice/stl/map.ipp
@@ -346,13 +346,6 @@ namespace Rice
               return MapFromHash<T, U>::convert(value);
             }
           }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::map<T, U>>();
-            }
-          }
           default:
           {
             throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
@@ -406,13 +399,6 @@ namespace Rice
             {
               this->converted_ = MapFromHash<T, U>::convert(value);
               return this->converted_;
-            }
-          }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::map<T, U>>();
             }
           }
           default:

--- a/rice/stl/multimap.ipp
+++ b/rice/stl/multimap.ipp
@@ -325,13 +325,6 @@ namespace Rice
               return toMultimap<T, U>(value);
             }
           }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::multimap<T, U>>();
-            }
-          }
           default:
           {
             throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
@@ -385,13 +378,6 @@ namespace Rice
             {
               this->converted_ = toMultimap<T, U>(value);
               return this->converted_;
-            }
-          }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::multimap<T, U>>();
             }
           }
           default:

--- a/rice/stl/set.ipp
+++ b/rice/stl/set.ipp
@@ -345,13 +345,6 @@ namespace Rice
             throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
               detail::protect(rb_obj_classname, value), "std::set");
           }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::set<T>>();
-            }
-          }
           default:
           {
             throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
@@ -420,13 +413,6 @@ namespace Rice
             }
             throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
               detail::protect(rb_obj_classname, value), "std::set");
-          }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::set<T>>();
-            }
           }
           default:
           {

--- a/rice/stl/shared_ptr.ipp
+++ b/rice/stl/shared_ptr.ipp
@@ -122,11 +122,6 @@ namespace Rice::detail
 
     std::shared_ptr<T> convert(VALUE value)
     {
-      if(value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->template defaultValue<std::shared_ptr<T>>();
-      }
-
       // Get the wrapper
       WrapperBase* wrapperBase = detail::getWrapper(value);
 
@@ -197,11 +192,6 @@ namespace Rice::detail
 
     std::shared_ptr<T>& convert(VALUE value)
     {
-      if(value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->template defaultValue<std::shared_ptr<T>>();
-      }
-
       // Get the wrapper
       WrapperBase* wrapperBase = detail::getWrapper(value);
 

--- a/rice/stl/string.ipp
+++ b/rice/stl/string.ipp
@@ -87,15 +87,8 @@ namespace Rice::detail
 
     std::string convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<std::string>();
-      }
-      else
-      {
-        detail::protect(rb_check_type, value, (int)T_STRING);
-        return std::string(RSTRING_PTR(value), RSTRING_LEN(value));
-      }
+      detail::protect(rb_check_type, value, (int)T_STRING);
+      return std::string(RSTRING_PTR(value), RSTRING_LEN(value));
     }
 
   private:
@@ -126,16 +119,9 @@ namespace Rice::detail
 
     std::string& convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<std::string>();
-      }
-      else
-      {
-        detail::protect(rb_check_type, value, (int)T_STRING);
-        this->converted_ = std::string(RSTRING_PTR(value), RSTRING_LEN(value));
-        return this->converted_;
-      }
+      detail::protect(rb_check_type, value, (int)T_STRING);
+      this->converted_ = std::string(RSTRING_PTR(value), RSTRING_LEN(value));
+      return this->converted_;
     }
 
   private:

--- a/rice/stl/string_view.ipp
+++ b/rice/stl/string_view.ipp
@@ -55,15 +55,8 @@ namespace Rice::detail
 
     std::string_view convert(VALUE value)
     {
-      if (value == Qnil && this->arg_ && this->arg_->hasDefaultValue())
-      {
-        return this->arg_->defaultValue<std::string_view>();
-      }
-      else
-      {
-        detail::protect(rb_check_type, value, (int)T_STRING);
-        return std::string_view(RSTRING_PTR(value), RSTRING_LEN(value));
-      }
+      detail::protect(rb_check_type, value, (int)T_STRING);
+      return std::string_view(RSTRING_PTR(value), RSTRING_LEN(value));
     }
 
   private:

--- a/rice/stl/unordered_map.ipp
+++ b/rice/stl/unordered_map.ipp
@@ -346,13 +346,6 @@ namespace Rice
               return UnorderedMapFromHash<T, U>::convert(value);
             }
           }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::unordered_map<T, U>>();
-            }
-          }
           default:
           {
             throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
@@ -406,13 +399,6 @@ namespace Rice
             {
               this->converted_ = UnorderedMapFromHash<T, U>::convert(value);
               return this->converted_;
-            }
-          }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::unordered_map<T, U>>();
             }
           }
           default:

--- a/rice/stl/vector.ipp
+++ b/rice/stl/vector.ipp
@@ -449,13 +449,6 @@ namespace Rice
               return Array(value).to_vector<T>();
             }
           }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::vector<T>>();
-            }
-          }
           default:
           {
             throw Exception(rb_eTypeError, "wrong argument type %s (expected % s)",
@@ -511,13 +504,6 @@ namespace Rice
             {
               this->converted_ = Array(value).to_vector<T>();
               return this->converted_;
-            }
-          }
-          case RUBY_T_NIL:
-          {
-            if (this->arg_ && this->arg_->hasDefaultValue())
-            {
-              return this->arg_->template defaultValue<std::vector<T>>();
             }
           }
           default:

--- a/test/test_Callback.cpp
+++ b/test/test_Callback.cpp
@@ -139,7 +139,7 @@ namespace
   using Callback_T2 = char*(*)();
   std::vector<Callback_T2> callbacks;
 
-  void registerCallback(Callback_T2 callback1, Callback_T2 callback2)
+  void registerTwoCallbacks(Callback_T2 callback1, Callback_T2 callback2)
   {
     callbacks.push_back(callback1);
     callbacks.push_back(callback2);
@@ -156,7 +156,7 @@ namespace
 TESTCASE(MultipleCallbacks)
 {
   Module m = define_module("TestingMultipleCallbacks");
-  m.define_module_function<void(*)(Callback_T2, Callback_T2)>("register_callback", registerCallback).
+  m.define_module_function<void(*)(Callback_T2, Callback_T2)>("register_callback", registerTwoCallbacks).
     define_module_function<char*(*)(int)>("trigger_callback", triggerCallback);
 
   std::string code = R"(proc1 = Proc.new do 

--- a/test/test_Module.cpp
+++ b/test/test_Module.cpp
@@ -188,7 +188,7 @@ TESTCASE(method_int_passed_no_args)
   ASSERT_EXCEPTION_CHECK(
     Exception,
     m.module_eval("o = Object.new; o.extend(self); o.foo"),
-    ASSERT_EQUAL("wrong number of arguments (given 0, expected 1)", ex.what())
+    ASSERT_EQUAL("Missing argument. Name: arg_0. Index: 0.", ex.what())
   );
 }
 
@@ -273,7 +273,7 @@ TESTCASE(default_arguments_still_throws_argument_error)
   ASSERT_EXCEPTION_CHECK(
     Exception,
     m.module_eval("o = Object.new; o.extend(self); o.foo()"),
-    ASSERT_EQUAL("wrong number of arguments (given 0, expected 1..3)", ex.what())
+    ASSERT_EQUAL("Missing argument. Name: arg1. Index: 0.", ex.what())
   );
 
   ASSERT_EXCEPTION_CHECK(
@@ -285,7 +285,7 @@ TESTCASE(default_arguments_still_throws_argument_error)
   ASSERT_EXCEPTION_CHECK(
     Exception,
     m.module_eval("o = Object.new; o.extend(self); o.foo(3, 4, false, 17)"),
-    ASSERT_EQUAL("wrong number of arguments (given 4, expected 1..3)", ex.what())
+    ASSERT_EQUAL("wrong number of arguments (given 4, expected 3)", ex.what())
   );
 }
 

--- a/test/test_global_functions.cpp
+++ b/test/test_global_functions.cpp
@@ -16,8 +16,8 @@ TEARDOWN(GlobalFunctions)
   rb_gc_start();
 }
 
-namespace {
-
+namespace
+{
   bool no_args()
   {
     return true;
@@ -136,8 +136,8 @@ TESTCASE(default_arguments_for_define_global_function)
 
 TESTCASE(default_arguments_kw)
 {
-  define_global_function("defaults_method_one_kw", &defaults_method_one, 
-    Arg("arg1"), Arg("arg2"), Arg("arg3") = true);
+  define_global_function("defaults_method_one_kw", &defaults_method_one,
+    Arg("arg1"), Arg("arg2") = 3, Arg("arg3") = true);
   Module m = Module(rb_mKernel);
 
   std::string code = R"(defaults_method_one_kw(4, arg2: 5))";
@@ -151,6 +151,19 @@ TESTCASE(default_arguments_kw)
   ASSERT_EQUAL(9, defaults_method_one_arg1);
   ASSERT_EQUAL(11, defaults_method_one_arg2);
   ASSERT(!defaults_method_one_arg3);
+
+  code = R"(defaults_method_one_kw(4, arg3: false))";
+  m.instance_eval(code);
+  ASSERT_EQUAL(4, defaults_method_one_arg1);
+  ASSERT_EQUAL(3, defaults_method_one_arg2);
+  ASSERT_EQUAL(false, defaults_method_one_arg3);
+
+  code = R"(defaults_method_one_kw(arg2: 5))";
+  ASSERT_EXCEPTION_CHECK(
+    Exception,
+    m.instance_eval(code),
+    ASSERT_EQUAL("Missing argument. Name: arg1. Index: 0.", ex.what())
+  );
 }
 
 TESTCASE(default_arguments_and_returning)


### PR DESCRIPTION
Large changeset that makes handling of keyword arguments more robust. Previously if a keyword argument was skipped, even if it had a default value, Rice would crash. As part of this handling of default values moved to NativeFunction from FromRuby. This centralizes the code and removes a lot of boilerplate.