### PR TITLE
Fix header check on Ubuntu 22.04

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2025]
         ruby: ['3.1', '3.2', '3.3', '3.4']
+        include:
+          - os: ubuntu-22.04
+            ruby: '3.1'
         exclude:
           # There's something wrong with this setup in GHA such that
           # it gets weird linking errors, however I'm unable to reproduce

--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -73,6 +73,7 @@ extern "C" typedef VALUE (*RUBY_VALUE_FUNC)(VALUE);
 // =========   rice_traits.hpp   =========
 
 #include <ostream>
+#include <tuple>
 #include <type_traits>
 #include <variant>
 #include <vector>
@@ -588,6 +589,7 @@ namespace Rice::detail
 // =========   RubyFunction.ipp   =========
 
 #include <any>
+#include <tuple>
 
 namespace Rice::detail
 {
@@ -9480,6 +9482,7 @@ namespace Rice::detail
 #include <array>
 #include <stdexcept>
 #include <sstream>
+#include <tuple>
 
 namespace Rice::detail
 {
@@ -10223,6 +10226,7 @@ namespace Rice::detail
 
 // =========   NativeCallbackFFI.ipp   =========
 #ifdef HAVE_LIBFFI
+#include <tuple>
 #include <ffi.h>
 
 namespace Rice::detail

--- a/rice/detail/NativeCallbackFFI.ipp
+++ b/rice/detail/NativeCallbackFFI.ipp
@@ -1,4 +1,5 @@
 #ifdef HAVE_LIBFFI
+#include <tuple>
 #include <ffi.h>
 
 namespace Rice::detail

--- a/rice/detail/NativeFunction.ipp
+++ b/rice/detail/NativeFunction.ipp
@@ -2,6 +2,7 @@
 #include <array>
 #include <stdexcept>
 #include <sstream>
+#include <tuple>
 
 namespace Rice::detail
 {

--- a/rice/detail/RubyFunction.ipp
+++ b/rice/detail/RubyFunction.ipp
@@ -1,5 +1,6 @@
 
 #include <any>
+#include <tuple>
 
 namespace Rice::detail
 {

--- a/rice/traits/rice_traits.hpp
+++ b/rice/traits/rice_traits.hpp
@@ -2,6 +2,7 @@
 #define Rice__detail__traits__hpp_
 
 #include <ostream>
+#include <tuple>
 #include <type_traits>
 #include <variant>
 #include <vector>


### PR DESCRIPTION
Currently, gems that rely on Rice fail to compile with Rice 4.6 on Ubuntu 22.04 due to a missing header.

Relevant console output

```text
checking for rice/rice.hpp in /home/runner/work/faiss-ruby/faiss-ruby/vendor/bundle/ruby/3.3.0/gems/rice-4.6.0/include... no
/home/runner/work/faiss-ruby/faiss-ruby/vendor/bundle/ruby/3.3.0/gems/rice-4.6.0/lib/mkmf-rice.rb:42:in `<top (required)>': Could not find rice/rice.hpp header (RuntimeError)
   from /opt/hostedtoolcache/Ruby/3.3.8/x64/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
   from /opt/hostedtoolcache/Ruby/3.3.8/x64/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
   from ../../../../ext/faiss/extconf.rb:1:in `<main>'
rake aborted!
```

Relevant `mkmf.log` contents

```text
In file included from conftest.cc:3:
/home/runner/work/faiss-ruby/faiss-ruby/vendor/bundle/ruby/3.3.0/gems/rice-4.6.0/include/rice/rice.hpp: In function ‘void Rice::detail::for_each_tuple(Tuple_T&&, Function_T&&)’:
/home/runner/work/faiss-ruby/faiss-ruby/vendor/bundle/ruby/3.3.0/gems/rice-4.6.0/include/rice/rice.hpp:223:12: error: ‘apply’ is not a member of ‘std’
  223 |       std::apply([&callable](auto&& ...args)
      |            ^~~~~
In file included from conftest.cc:3:
/home/runner/work/faiss-ruby/faiss-ruby/vendor/bundle/ruby/3.3.0/gems/rice-4.6.0/include/rice/rice.hpp:79:1: note: ‘std::apply’ is defined in header ‘<tuple>’; did you forget to ‘#include <tuple>’?
   78 | #include <vector>
  +++ |+#include <tuple>
   79 | 
checked program was:
/* begin */
1: #include "ruby.h"
2: 
3: #include <rice/rice.hpp>
/* end */
```

This PR adds `#include <tuple>` to files that use `std::apply`.