### PR TITLE
Improve attribute handling.

### DIFF
--- a/rice/Data_Type.hpp
+++ b/rice/Data_Type.hpp
@@ -166,6 +166,9 @@ namespace Rice
     template<bool IsMethod, typename Function_T>
     void wrap_native_call(VALUE klass, std::string name, Function_T&& function, MethodInfo* methodInfo);
 
+    template <typename Attribute_T>
+    Data_Type<T>& define_attr_internal(VALUE klass, std::string name, Attribute_T attribute, AttrAccess access);
+
   private:
     template<typename T_>
     friend class Data_Type;

--- a/rice/detail/NativeAttributeSet.ipp
+++ b/rice/detail/NativeAttributeSet.ipp
@@ -42,39 +42,21 @@ namespace Rice::detail
   template<typename Attribute_T>
   inline VALUE NativeAttributeSet<Attribute_T>::operator()(size_t argc, const VALUE* argv, VALUE self)
   {
-    if constexpr (std::is_fundamental_v<intrinsic_type<Attr_T>> && std::is_pointer_v<Attr_T>)
-    {
-      static_assert(true, "An fundamental value, such as an integer, cannot be assigned to an attribute that is a pointer.");
-    }
-    else if constexpr (std::is_same_v<intrinsic_type<Attr_T>, std::string> && std::is_pointer_v<Attr_T>)
-    {
-      static_assert(true, "An string cannot be assigned to an attribute that is a pointer.");
-    }
-
     if (argc != 1)
     {
       throw std::runtime_error("Incorrect number of parameters for setting attribute. Attribute: " + this->name_);
     }
 
     VALUE value = argv[0];
-    
-    if constexpr (!std::is_null_pointer_v<Receiver_T> && 
-                  !std::is_const_v<Attr_T> && 
-                  (std::is_fundamental_v<Attr_T> || std::is_assignable_v<Attr_T, Attr_T>))
+
+    if constexpr (!std::is_null_pointer_v<Receiver_T>)
     {
       Receiver_T* nativeSelf = From_Ruby<Receiver_T*>().convert(self);
       nativeSelf->*attribute_ = From_Ruby<T_Unqualified>().convert(value);
     }
-    else if constexpr (std::is_null_pointer_v<Receiver_T> && 
-                       !std::is_const_v<Attr_T> &&
-                       (std::is_fundamental_v<Attr_T> || std::is_assignable_v<Attr_T, Attr_T>))
-    {
-      *attribute_ = From_Ruby<T_Unqualified>().convert(value);
-    }
     else
     {
-      // Should never get here because define_attr won't compile this code, but just in case!
-      throw std::invalid_argument("Could not set attribute. Attribute: " + this->name_);
+      *attribute_ = From_Ruby<T_Unqualified>().convert(value);
     }
 
     return value;

--- a/rice/traits/attribute_traits.hpp
+++ b/rice/traits/attribute_traits.hpp
@@ -9,17 +9,17 @@ namespace Rice::detail
   template<typename Attribute_T>
   struct attribute_traits;
 
-  template<typename Attr_T>
-  struct attribute_traits<Attr_T*>
+  template<typename Attribute_T>
+  struct attribute_traits<Attribute_T*>
   {
-    using attr_type = Attr_T;
+    using attr_type = Attribute_T;
     using class_type = std::nullptr_t;
   };
 
-  template<typename Attr_T, typename Class_T>
-  struct attribute_traits<Attr_T Class_T::*> 
+  template<typename Attribute_T, typename Class_T>
+  struct attribute_traits<Attribute_T(Class_T::*)>
   {
-    using attr_type = Attr_T;
+    using attr_type = Attribute_T;
     using class_type = Class_T;
   };
 }


### PR DESCRIPTION
 Correctly deal with non-copyable/assignable attributes and return references instead of copies of class types.