### PR TITLE
Fix missing return in initialize example

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -118,6 +118,7 @@ We can also add an ``#initialize`` method to our class:
   Object test_initialize(Object self)
   {
     self.iv_set("@foo", 42);
+    return self;
   }
 
   Object test_hello(Object /* self */)


### PR DESCRIPTION
The C++ example for the `test_initialize` method in the tutorial was missing a return statement. On my macOS environment, this caused a crash (trace trap) when the code was executed.