### PR TITLE
Introduce Pointer<T>

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,3 +34,9 @@ jobs:
       run: rake headers
     - name: Build and test
       run: rake test
+    - name: Mkmf.log
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: mkmf-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.ruby }}
+        path: test/mkmf.log

--- a/rice/Buffer.hpp
+++ b/rice/Buffer.hpp
@@ -10,11 +10,10 @@ namespace Rice
   class Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>
   {
   public:
-    using Element_T = T;
-
     Buffer(T* pointer);
     Buffer(T* pointer, size_t size);
     Buffer(VALUE value);
+    Buffer(VALUE value, size_t size);
 
     ~Buffer();
 
@@ -30,7 +29,6 @@ namespace Rice
     void release();
 
     size_t size() const;
-    void setSize(size_t value);
 
     // Ruby API
     VALUE toString() const;
@@ -45,8 +43,8 @@ namespace Rice
     void setOwner(bool value);
 
   private:
-    void fromBuiltinType(VALUE value);
-    void fromWrappedType(VALUE value);
+    void fromBuiltinType(VALUE value, size_t size);
+    void fromWrappedType(VALUE value, size_t size);
 
     bool m_owner = false;
     size_t m_size = 0;
@@ -59,11 +57,10 @@ namespace Rice
   class Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>
   {
   public:
-    using Element_T = Buffer<T>;
-
     Buffer(T** pointer);
     Buffer(T** pointer, size_t size);
     Buffer(VALUE value);
+    Buffer(VALUE value, size_t size);
 
     ~Buffer();
 
@@ -73,13 +70,12 @@ namespace Rice
     Buffer& operator=(const Buffer& other) = delete;
     Buffer& operator=(Buffer&& other);
 
-    Element_T& operator[](size_t index);
+    T*& operator[](size_t index);
 
     T** ptr();
     void release();
 
     size_t size() const;
-    void setSize(size_t value);
 
     // Ruby API
     VALUE toString() const;
@@ -96,19 +92,17 @@ namespace Rice
   private:
     bool m_owner = false;
     size_t m_size = 0;
-    T** m_outer = nullptr;
-    std::vector<Buffer<T>> m_inner;
+    T** m_buffer = nullptr;
   };
 
   template<typename T>
   class Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>
   {
   public:
-    using Element_T = T*;
-
     Buffer(T** pointer);
     Buffer(T** pointer, size_t size);
     Buffer(VALUE value);
+    Buffer(VALUE value, size_t size);
 
     ~Buffer();
 
@@ -118,13 +112,12 @@ namespace Rice
     Buffer& operator=(const Buffer& other) = delete;
     Buffer& operator=(Buffer&& other);
 
-    Element_T& operator[](size_t index);
+    T* operator[](size_t index);
 
     T** ptr();
     void release();
 
     size_t size() const;
-    void setSize(size_t value);
 
     // Ruby API
     VALUE toString() const;
@@ -150,15 +143,15 @@ namespace Rice
   public:
     Buffer(T* pointer);
     Buffer(VALUE value);
+    Buffer(VALUE value, size_t size);
+
     Buffer(const Buffer& other) = delete;
     Buffer(Buffer&& other);
-    ~Buffer();
 
     Buffer& operator=(const Buffer& other) = delete;
     Buffer& operator=(Buffer&& other);
 
     size_t size() const;
-    void setSize(size_t value);
       
     VALUE bytes(size_t count) const;
     VALUE bytes() const;
@@ -174,4 +167,5 @@ namespace Rice
   template<typename T>
   Data_Type<Buffer<T>> define_buffer(std::string klassName = "");
 }
+
 #endif // Rice__Buffer__hpp_

--- a/rice/Buffer.ipp
+++ b/rice/Buffer.ipp
@@ -12,15 +12,20 @@ namespace Rice
   }
 
   template <typename T>
-  inline Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::Buffer(VALUE value)
+  inline Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::Buffer(VALUE value) : Buffer(value, 0)
+  {
+  }
+
+  template <typename T>
+  inline Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::Buffer(VALUE value, size_t size)
   {
     if constexpr (std::is_fundamental_v<T>)
     {
-      this->fromBuiltinType(value);
+      this->fromBuiltinType(value, size);
     }
     else
     {
-      this->fromWrappedType(value);
+      this->fromWrappedType(value, size);
     }
   }
 
@@ -37,12 +42,12 @@ namespace Rice
   }
 
   template <typename T>
-  inline void Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::fromBuiltinType(VALUE value)
+  inline void Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::fromBuiltinType(VALUE value, size_t size)
   {
     using Intrinsic_T = typename detail::intrinsic_type<T>;
     using RubyType_T = typename detail::RubyType<Intrinsic_T>;
-    ruby_value_type valueType = rb_type(value);
 
+    ruby_value_type valueType = rb_type(value);
     switch (valueType)
     {
       case RUBY_T_ARRAY:
@@ -51,9 +56,19 @@ namespace Rice
         this->m_size = array.size();
         this->m_buffer = new T[this->m_size]();
 
-        String packed = array.pack<Intrinsic_T>();
-        memcpy((void*)this->m_buffer, RSTRING_PTR(packed.value()), RSTRING_LEN(packed.value()));
-
+        if constexpr (std::is_fundamental_v<T>)
+        {
+          String packed = array.pack<Intrinsic_T>();
+          memcpy((void*)this->m_buffer, RSTRING_PTR(packed.value()), RSTRING_LEN(packed.value()));
+        }
+        else
+        {
+          detail::From_Ruby<Intrinsic_T> fromRuby;
+          for (int i = 0; i < array.size(); i++)
+          {
+            this->m_buffer[0] = fromRuby.convert(array[i]);
+          }
+        }
         this->m_owner = true;
         break;
       }
@@ -76,14 +91,14 @@ namespace Rice
       }
       case RUBY_T_DATA:
       {
-        if (Data_Type<std::remove_cv_t<T>>::is_descendant(value))
+        if (Data_Type<Pointer<T>>::is_descendant(value))
         {
-          this->m_size = 1;
-          T* instance = detail::unwrap<T>(value, Data_Type<std::remove_cv_t<T>>::ruby_data_type(), false);
-          this->m_buffer = new T[this->m_size]{*instance};
+          this->m_buffer = detail::unwrap<T>(value, Data_Type<Pointer<T>>::ruby_data_type(), false);
           this->m_owner = false;
+          this->m_size = size;
           break;
         }
+        [[fallthrough]];
       }
       default:
       {
@@ -110,7 +125,7 @@ namespace Rice
   }
 
   template <typename T>
-  inline void Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::fromWrappedType(VALUE value)
+  inline void Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::fromWrappedType(VALUE value, size_t size)
   {
     using Intrinsic_T = typename detail::intrinsic_type<T>;
 
@@ -121,8 +136,11 @@ namespace Rice
         Array array(value);
         this->m_size = array.size();
 
-        // Use operator new[] to allocate memory but not call constructors
-        this->m_buffer = static_cast<T*>(operator new[](sizeof(T)* this->m_size));
+        // Use operator new[] to allocate memory but not call constructors. Memset to 0 so that
+        // if an object implements move assignment it won't blow up.
+        size_t size = sizeof(T) * this->m_size;
+        this->m_buffer = static_cast<T*>(operator new[](size));
+        std::memset(this->m_buffer, 0, size);
 
         detail::From_Ruby<Intrinsic_T> fromRuby;
 
@@ -131,6 +149,32 @@ namespace Rice
           this->m_buffer[i] = fromRuby.convert(array[i].value());
         }
         break;
+      }
+      case RUBY_T_DATA:
+      {
+        if (Data_Type<Intrinsic_T>::is_descendant(value))
+        {
+          this->m_buffer = detail::unwrap<T>(value, Data_Type<Intrinsic_T>::ruby_data_type(), false);
+          this->m_owner = false;
+          this->m_size = size;
+          break;
+        }
+      }
+      case RUBY_T_STRING:
+      {
+        // This special case is a bit ugly...
+        if constexpr (std::is_same_v<detail::intrinsic_type<T>, std::string>)
+        {
+          // FromRuby owns the converted string so we need to keep it alive until we get to the copy constructor
+          // two lines down
+          detail::From_Ruby<T*> fromRuby;
+          T* converted = fromRuby.convert(value);
+          this->m_buffer = new T[1]{ *converted };
+          this->m_owner = true;
+          this->m_size = 1;
+          break;
+        }
+        [[fallthrough]];
       }
       default:
       {
@@ -169,12 +213,6 @@ namespace Rice
   inline size_t Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::size() const
   {
     return this->m_size;
-  }
-
-  template <typename T>
-  inline void Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::setSize(size_t value)
-  {
-    this->m_size = value;
   }
 
   template <typename T>
@@ -271,7 +309,7 @@ namespace Rice
   }
 
   template<typename T>
-  inline typename Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::Element_T& Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::operator[](size_t index)
+  inline T& Buffer<T, std::enable_if_t<!std::is_pointer_v<T> && !std::is_void_v<T>>>::operator[](size_t index)
   {
     if (index >= this->m_size)
     {
@@ -283,45 +321,72 @@ namespace Rice
 
   // ----  Buffer<T*> - Builtin ------- 
   template<typename T>
-  inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(T** pointer) : m_outer(pointer)
+  inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(T** pointer) : m_buffer(pointer)
   {
   }
 
   template<typename T>
-  inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(T** pointer, size_t size) : m_outer(pointer), m_size(size)
+  inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(T** pointer, size_t size) : m_buffer(pointer), m_size(size)
   {
   }
 
   template <typename T>
-  inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(VALUE value)
+  inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(VALUE value) : Buffer(value, 0)
   {
-    ruby_value_type valueType = rb_type(value);
+  }
+ 
+  template <typename T>
+  inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(VALUE value, size_t size)
+  {
+    using Intrinsic_T = typename detail::intrinsic_type<T>;
 
+    ruby_value_type valueType = rb_type(value);
     switch (valueType)
     {
       case RUBY_T_ARRAY:
       {
         Array outer(value);
+
+        // Allocate outer buffer
         this->m_size = outer.size();
-        this->m_outer = new T * [this->m_size]();
+        this->m_buffer = new T*[this->m_size]();
 
         for (size_t i = 0; i < this->m_size; i++)
         {
           // Check the inner value is also an array
           Array inner(outer[i].value());
 
-          // Wrap it with a buffer and add it our list of inner buffers
-          Buffer<T> buffer(inner.value());
+          // Allocate inner buffer
+          this->m_buffer[i] = new T[inner.size()]();
 
-          // And update the outer array
-          this->m_outer[i] = buffer.ptr();
-
-          // Now move the buffer into the affer, not the buffer pointer is still valid (it just got moved)
-          this->m_inner.push_back(std::move(buffer));
+          if constexpr (std::is_fundamental_v<Intrinsic_T>)
+          {
+            String packed = inner.pack<Intrinsic_T>();
+            memcpy((void*)this->m_buffer[i], RSTRING_PTR(packed.value()), RSTRING_LEN(packed.value()));
+          }
+          else
+          {
+            detail::From_Ruby<Intrinsic_T*> fromRuby;
+            for (int i = 0; i < inner.size(); i++)
+            {
+              this->m_buffer[0] = fromRuby.convert(inner[i].value());
+            }
+          }
         }
 
         this->m_owner = true;
         break;
+      }
+      case RUBY_T_DATA:
+      {
+        if (Data_Type<Pointer<T*>>::is_descendant(value))
+        {
+          this->m_buffer = detail::unwrap<T*>(value, Data_Type<Pointer<T*>>::ruby_data_type(), false);
+          this->m_owner = false;
+          this->m_size = size;
+          break;
+        }
+        [[fallthrough]];
       }
       default:
       {
@@ -338,16 +403,20 @@ namespace Rice
   {
     if (this->m_owner)
     {
-      delete[] this->m_outer;
+      for (int i = 0; i < this->m_size; i++)
+      {
+        delete this->m_buffer[i];
+      }
+
+      delete[] this->m_buffer;
     }
   }
 
   template <typename T>
   inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Buffer(Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>&& other) : m_owner(other.m_owner), m_size(other.m_size),
-                                                  m_outer(other.m_outer), m_inner(std::move(other.m_inner))
+                                                  m_buffer(other.m_buffer)
   {
-    other.m_outer = nullptr;
-    other.m_inner.clear();
+    other.m_buffer = nullptr;
     other.m_size = 0;
     other.m_owner = false;
   }
@@ -355,11 +424,8 @@ namespace Rice
   template <typename T>
   inline Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>& Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::operator=(Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>&& other)
   {
-    this->m_outer = other.m_outer;
-    other.m_outer = nullptr;
-
-    this->m_inner = std::move(other.m_inner);
-    other.m_inner.clear();
+    this->m_buffer = other.m_buffer;
+    other.m_buffer = nullptr;
 
     this->m_size = other.m_size;
     other.m_size = 0;
@@ -371,9 +437,9 @@ namespace Rice
   }
 
   template <typename T>
-  inline typename Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::Element_T& Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::operator[](size_t index)
+  inline T*& Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::operator[](size_t index)
   {
-    return this->m_inner[index];
+    return this->m_buffer[index];
   }
 
   template <typename T>
@@ -383,15 +449,9 @@ namespace Rice
   }
 
   template <typename T>
-  inline void Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::setSize(size_t value)
-  {
-    this->m_size = value;
-  }
-
-  template <typename T>
   inline T** Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::ptr()
   {
-    return this->m_outer;
+    return this->m_buffer;
   }
 
   template <typename T>
@@ -425,13 +485,13 @@ namespace Rice
   template<typename T>
   inline VALUE Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::bytes(size_t count) const
   {
-    if (!this->m_outer)
+    if (!this->m_buffer)
     {
       return Qnil;
     }
     else
     {
-      T** begin = this->m_outer;
+      T** begin = this->m_buffer;
       long length = (long)(count * sizeof(T*));
       return detail::protect(rb_str_new_static, (const char*)*begin, length);
     }
@@ -446,7 +506,7 @@ namespace Rice
   template<typename T>
   inline Array Buffer<T*, std::enable_if_t<!detail::is_wrapped_v<T>>>::toArray(size_t count) const
   {
-    if (!this->m_outer)
+    if (!this->m_buffer)
     {
       return Qnil;
     }
@@ -454,8 +514,8 @@ namespace Rice
     {
       Array result;
 
-      T** ptr = this->m_outer;
-      T** end = this->m_outer + count;
+      T** ptr = this->m_buffer;
+      T** end = this->m_buffer + count;
 
       for (; ptr < end; ptr++)
       {
@@ -484,10 +544,16 @@ namespace Rice
   }
 
   template <typename T>
-  inline Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::Buffer(VALUE value)
+  inline Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::Buffer(VALUE value) : Buffer(value, 0)
   {
-    ruby_value_type valueType = rb_type(value);
+  }
+  
+  template <typename T>
+  inline Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::Buffer(VALUE value, size_t size)
+  {
+    using Intrinsic_T = typename detail::intrinsic_type<T>;
 
+    ruby_value_type valueType = rb_type(value);
     switch (valueType)
     {
       case RUBY_T_ARRAY:
@@ -496,15 +562,25 @@ namespace Rice
         this->m_size = array.size();
         this->m_buffer = new T * [this->m_size]();
 
-        detail::From_Ruby<T> fromRuby;
+        detail::From_Ruby<T*> fromRuby;
+
         for (size_t i = 0; i < this->m_size; i++)
         {
-          Data_Object<detail::intrinsic_type<T>> dataObject(array[i].value());
-          this->m_buffer[i] = dataObject.get();
+          this->m_buffer[i] = fromRuby.convert(array[i].value());
         }
 
         this->m_owner = true;
         break;
+      }
+      case RUBY_T_DATA:
+      {
+        if (Data_Type<Pointer<T*>>::is_descendant(value))
+        {
+          this->m_buffer = detail::unwrap<T*>(value, Data_Type<Pointer<T*>>::ruby_data_type(), false);
+          this->m_owner = false;
+          this->m_size = size;
+          break;
+        }
       }
       default:
       {
@@ -550,7 +626,7 @@ namespace Rice
   }
 
   template <typename T>
-  inline typename Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::Element_T& Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::operator[](size_t index)
+  inline T* Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::operator[](size_t index)
   {
     if (index >= this->m_size)
     {
@@ -563,12 +639,6 @@ namespace Rice
   inline size_t Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::size() const
   {
     return this->m_size;
-  }
-
-  template <typename T>
-  inline void Buffer<T*, std::enable_if_t<detail::is_wrapped_v<T>>>::setSize(size_t value)
-  {
-    this->m_size = value;
   }
 
   template <typename T>
@@ -656,7 +726,12 @@ namespace Rice
 
   // ----  Buffer<void> ------- 
   template<typename T>
-  inline Buffer<T, std::enable_if_t<std::is_void_v<T>>>::Buffer(VALUE value)
+  inline Buffer<T, std::enable_if_t<std::is_void_v<T>>>::Buffer(VALUE value) : Buffer(value, 0)
+  {
+  }
+  
+  template<typename T>
+  inline Buffer<T, std::enable_if_t<std::is_void_v<T>>>::Buffer(VALUE value, size_t size)
   {
     ruby_value_type valueType = rb_type(value);
 
@@ -695,15 +770,6 @@ namespace Rice
   }
 
   template<typename T>
-  inline Buffer<T, std::enable_if_t<std::is_void_v<T>>>::~Buffer()
-  {
-    if (this->m_owner)
-    {
-      delete this->m_buffer;
-    }
-  }
-
-  template<typename T>
   inline Buffer<T, std::enable_if_t<std::is_void_v<T>>>& Buffer<T, std::enable_if_t<std::is_void_v<T>>>::operator=(Buffer<T, std::enable_if_t<std::is_void_v<T>>>&& other)
   {
     this->m_buffer = other.m_buffer;
@@ -718,12 +784,6 @@ namespace Rice
     return this->m_size;
   }
 
-  template<typename T>
-  inline void Buffer<T, std::enable_if_t<std::is_void_v<T>>>::setSize(size_t value)
-  {
-    this->m_size = value;
-  }
-  
   template<typename T>
   inline T* Buffer<T, std::enable_if_t<std::is_void_v<T>>>::ptr()
   {
@@ -758,7 +818,7 @@ namespace Rice
 
     if (klassName.empty())
     {
-      detail::TypeMapper<Buffer<T>> typeMapper;
+      detail::TypeMapper<Buffer_T> typeMapper;
       klassName = typeMapper.rubyName();
     }
 
@@ -773,43 +833,38 @@ namespace Rice
     {
       return define_class_under<Buffer_T>(rb_mRice, klassName).
         define_constructor(Constructor<Buffer_T, VALUE>(), Arg("value").setValue()).
+        define_constructor(Constructor<Buffer_T, VALUE, size_t>(), Arg("value").setValue(), Arg("size")).
         define_method("size", &Buffer_T::size).
-        define_method("size=", &Buffer_T::setSize).
         template define_method<VALUE(Buffer_T::*)(size_t) const>("bytes", &Buffer_T::bytes, Return().setValue()).
-        template define_method<VALUE(Buffer_T::*)() const>("bytes", &Buffer_T::bytes, Return().setValue());
+        template define_method<VALUE(Buffer_T::*)() const>("bytes", &Buffer_T::bytes, Return().setValue()).
+        define_method("data", &Buffer_T::ptr, Return().setArray());
     }
     else
     {
       Data_Type<Buffer_T> klass = define_class_under<Buffer_T>(rb_mRice, klassName).
         define_constructor(Constructor<Buffer_T, VALUE>(), Arg("value").setValue()).
+        define_constructor(Constructor<Buffer_T, VALUE, size_t>(), Arg("value").setValue(), Arg("size")).
         define_method("size", &Buffer_T::size).
-        define_method("size=", &Buffer_T::setSize).
         template define_method<VALUE(Buffer_T::*)() const>("to_s", &Buffer_T::toString, Return().setValue()).
         template define_method<VALUE(Buffer_T::*)(size_t) const>("bytes", &Buffer_T::bytes, Return().setValue()).
         template define_method<VALUE(Buffer_T::*)() const>("bytes", &Buffer_T::bytes, Return().setValue()).
         template define_method<Array(Buffer_T::*)(size_t) const>("to_ary", &Buffer_T::toArray, Return().setValue()).
         template define_method<Array(Buffer_T::*)() const>("to_ary", &Buffer_T::toArray, Return().setValue()).
-        define_method("[]", &Buffer_T::operator[], Arg("index"));
+        define_method("[]", &Buffer_T::operator[], Arg("index")).
+        define_method("data", &Buffer_T::ptr, Return().setArray());
 
-      if constexpr (std::is_pointer_v<T> && detail::is_wrapped_v<T>)
+      if constexpr (!std::is_pointer_v<T> && !std::is_void_v<T> && !std::is_const_v<T> && std::is_copy_assignable_v<T>)
       {
-        klass.define_method("[]=", [](Buffer_T& self, size_t index, typename Buffer_T::Element_T element) -> void
+        klass.define_method("[]=", [](Buffer_T& self, size_t index, T& value) -> void
         {
-          self[index] = element;
+          self[index] = value;
         });
       }
-      else if constexpr (std::is_pointer_v<T> && !detail::is_wrapped_v<T>)
+      else if constexpr (std::is_pointer_v<T> && !std::is_const_v<std::remove_pointer_t<T>> && std::is_copy_assignable_v<std::remove_pointer_t<T>>)
       {
-        klass.define_method("[]=", [](Buffer_T& self, size_t index, typename Buffer_T::Element_T& element) -> void
+        klass.define_method("[]=", [](Buffer_T& self, size_t index, T value) -> void
         {
-          self[index] = std::move(element);
-        });
-      }
-      else if constexpr (std::is_copy_assignable_v<typename Buffer_T::Element_T>)
-      {
-        klass.define_method("[]=", [](Buffer_T& self, size_t index, typename Buffer_T::Element_T& element) -> void
-        {
-          self[index] = element;
+          *self[index] = *value;
         });
       }
 
@@ -817,22 +872,3 @@ namespace Rice
     }
   }
 }
-
-/*namespace Rice::detail
-{
-  template<typename T>
-  struct Type<Buffer<T>>
-  {
-    static bool verify()
-    {
-      Type<intrinsic_type<T>>::verify();
-
-      if (!Data_Type<Buffer<T>>::is_defined())
-      {
-        define_buffer<T>();
-      }
-
-      return true;
-    }
-  };
-}*/

--- a/rice/Data_Type.hpp
+++ b/rice/Data_Type.hpp
@@ -12,8 +12,6 @@ namespace Rice
   template<typename T>
   class Data_Type : public Class
   {
-    static_assert(std::is_same_v<detail::intrinsic_type<T>, T>);
-
   public:
     using type = T;
 

--- a/rice/Init.hpp
+++ b/rice/Init.hpp
@@ -1,8 +1,0 @@
-#ifndef Rice__Init__hpp_
-#define Rice__Init__hpp_
-
-namespace Rice
-{
-  void init();
-}
-#endif // Rice__Init__hpp_

--- a/rice/Init.ipp
+++ b/rice/Init.ipp
@@ -1,7 +1,0 @@
-namespace Rice
-{
-  inline void init()
-  {
-    detail::define_ruby_types();
-  };
-}

--- a/rice/Pointer.hpp
+++ b/rice/Pointer.hpp
@@ -1,0 +1,15 @@
+#ifndef Rice__Pointer__hpp_
+#define Rice__Pointer__hpp_
+
+namespace Rice
+{
+  template<typename T>
+  class Pointer
+  {
+  };
+
+  template<typename T>
+  Data_Type<Pointer<T>> define_pointer(std::string klassName = "");
+}
+
+#endif // Rice__Pointer__hpp_

--- a/rice/Pointer.ipp
+++ b/rice/Pointer.ipp
@@ -1,0 +1,32 @@
+namespace Rice
+{
+  template<typename T>
+  inline Data_Type<Pointer<T>> define_pointer(std::string klassName)
+  {
+    using Pointer_T = Pointer<T>;
+    using Data_Type_T = Data_Type<Pointer_T>;
+
+    if (klassName.empty())
+    {
+      detail::TypeMapper<Pointer_T> typeMapper;
+      klassName = typeMapper.rubyName();
+    }
+
+    Module rb_mRice = define_module("Rice");
+
+    if (Data_Type_T::check_defined(klassName, rb_mRice))
+    {
+      return Data_Type_T();
+    }
+
+    Data_Type<Pointer<T>> result = define_class_under<Pointer_T>(rb_mRice, klassName).
+      define_method("buffer", [](VALUE self) -> Buffer<T>
+      {
+        T* ptr = detail::unwrap<T>(self, Data_Type<Pointer<T>>::ruby_data_type(), false);
+        Buffer<T> buffer(ptr);
+        return buffer;
+      }, Arg("self").setValue());
+
+    return result;
+  }
+}

--- a/rice/detail/RubyType.hpp
+++ b/rice/detail/RubyType.hpp
@@ -9,8 +9,6 @@ namespace Rice::detail
   class RubyType
   {
   };
-
-  void define_ruby_types();
 }
 
 #endif // Rice__detail__ruby__type__hpp_

--- a/rice/detail/RubyType.ipp
+++ b/rice/detail/RubyType.ipp
@@ -212,36 +212,3 @@ namespace Rice::detail
     static inline std::string name = "void";
   };
 }
-
-namespace Rice::detail
-{
-  template<typename T>
-  inline Data_Type<T> define_ruby_type()
-  {
-    TypeMapper<T*> typeMapper;
-    std::string klassName = typeMapper.rubyName();
-    Identifier id(klassName);
-
-    Module rb_mRice = define_module("Rice");
-    return define_class_under<T>(rb_mRice, id);
-  }
-
-  inline void define_ruby_types()
-  {
-    define_ruby_type<bool>();
-    define_ruby_type<char>();
-    define_ruby_type<signed char>();
-    define_ruby_type<unsigned char>();
-    define_ruby_type<short>();
-    define_ruby_type<unsigned short>();
-    define_ruby_type<int>();
-    define_ruby_type<unsigned int>();
-    define_ruby_type<long>();
-    define_ruby_type<unsigned long>();
-    define_ruby_type<long long>();
-    define_ruby_type<unsigned long long>();
-    define_ruby_type<float>();
-    define_ruby_type<double>();
-    define_ruby_type<void>();
-  }
-}

--- a/rice/detail/TypeRegistry.ipp
+++ b/rice/detail/TypeRegistry.ipp
@@ -13,22 +13,6 @@ namespace Rice::detail
     registry_[key] = std::pair(klass, rbType);
   }
 
-  /* Special case void. Rice defines classes using the class name not a pointer to the
-     class. Thus define_class<void> is more consistent with Rice then 
-     define_class<void*>. However, the types of void and void* are different so we need
-     this special case.
-     
-     It is possible to support define_class<void*>, but it requires changing the static
-     assertions on Data_Type and Data_Object and thus seems less desirable (and less 
-     consistent as mentioned above).*/
-  template <>
-  inline void TypeRegistry::add<void>(VALUE klass, rb_data_type_t* rbType)
-  {
-    // The special case, use void*
-    std::type_index key(typeid(void*));
-    registry_[key] = std::pair(klass, rbType);
-  }
-
   template <typename T>
   inline void TypeRegistry::remove()
   {
@@ -59,15 +43,6 @@ namespace Rice::detail
       // Make compiler happy
       return std::make_pair(Qnil, nullptr);
     }
-  }
-
-  // Special case void. See comment for add above.
-  template <>
-  inline bool TypeRegistry::isDefined<void>()
-  {
-    std::type_index key(typeid(void*));
-    auto iter = registry_.find(key);
-    return iter != registry_.end();
   }
 
   template <typename T>

--- a/rice/detail/Types.ipp
+++ b/rice/detail/Types.ipp
@@ -1,5 +1,43 @@
 namespace Rice::detail
 {
+  template<typename T>
+  struct Type<T*>
+  {
+    static bool verify()
+    {
+      if constexpr (std::is_fundamental_v<T>)
+      {
+        define_pointer<T>();
+        define_buffer<T>();
+        return true;
+      }
+      else
+      {
+        return Type<T>::verify();
+      }
+    }
+  };
+
+  template<typename T>
+  struct Type<T**>
+  {
+    static bool verify()
+    {
+      define_pointer<T*>();
+      define_buffer<T*>();
+
+      if constexpr (std::is_fundamental_v<T>)
+      {
+        return true;
+      }
+      else
+      {
+        return Type<T>::verify();
+      }
+    }
+  };
+
+
   template<>
   struct Type<bool>
   {
@@ -403,278 +441,6 @@ namespace Rice::detail
     static VALUE rubyKlass()
     {
       return rb_cString;
-    }
-  };
-
-  template<>
-  struct Type<bool*>
-  {
-    static bool verify()
-    {
-      define_buffer<bool>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<bool>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<char**>
-  {
-    static bool verify()
-    {
-      define_buffer<char*>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<char*>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<unsigned char*>
-  {
-    static bool verify()
-    {
-      define_buffer<unsigned char>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<unsigned char>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<unsigned char**>
-  {
-    static bool verify()
-    {
-      define_buffer<unsigned char*>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<unsigned char*>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<signed char*>
-  {
-    static bool verify()
-    {
-      define_buffer<signed char>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<signed char>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<short*>
-  {
-    static bool verify()
-    {
-      define_buffer<short>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<short>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<unsigned short*>
-  {
-    static bool verify()
-    {
-      define_buffer<unsigned short>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<unsigned short>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<int*>
-  {
-    static bool verify()
-    {
-      define_buffer<int>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<int>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<unsigned int*>
-  {
-    static bool verify()
-    {
-      define_buffer<unsigned int>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<unsigned int>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<long*>
-  {
-    static bool verify()
-    {
-      define_buffer<long>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<long>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<unsigned long*>
-  {
-    static bool verify()
-    {
-      define_buffer<unsigned long>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<unsigned long>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<long long*>
-  {
-    static bool verify()
-    {
-      define_buffer<long long>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<long long>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<unsigned long long*>
-  {
-    static bool verify()
-    {
-      define_buffer<unsigned long long>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<unsigned long long>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<float*>
-  {
-    static bool verify()
-    {
-      define_buffer<float>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<float>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<double*>
-  {
-    static bool verify()
-    {
-      define_buffer<double>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<double>>();
-      return pair.first;
-    }
-  };
-
-  template<>
-  struct Type<void*>
-  {
-    static bool verify()
-    {
-      define_buffer<void>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<void>>();
-      return pair.first;
-    }
-  };
-
-  template<typename T>
-  struct Type<T**>
-  {
-    static bool verify()
-    {
-      define_buffer<T*>();
-      return true;
-    }
-
-    static VALUE rubyKlass()
-    {
-      std::pair<VALUE, rb_data_type_t*> pair = Registries::instance.types.getType<Buffer<T*>>();
-      return pair.first;
     }
   };
 }

--- a/rice/detail/Wrapper.hpp
+++ b/rice/detail/Wrapper.hpp
@@ -63,6 +63,18 @@ namespace Rice::detail
     T* data_ = nullptr;
   };
 
+  template <typename T>
+  class Wrapper<T**> : public WrapperBase
+  {
+  public:
+    Wrapper(T** data, bool isOwner);
+    ~Wrapper();
+    void* get() override;
+
+  private:
+    T** data_ = nullptr;
+  };
+
   // ---- Helper Functions ---------
   template <typename T>
   void wrapConstructed(VALUE value, rb_data_type_t* rb_data_type, T* data, bool isOwner);

--- a/rice/detail/Wrapper.ipp
+++ b/rice/detail/Wrapper.ipp
@@ -94,6 +94,33 @@ namespace Rice::detail
     return (void*)this->data_;
   }
 
+  // ----  Wrapper** -----
+  template <typename T>
+  inline Wrapper<T**>::Wrapper(T** data, bool isOwner) : data_(data)
+  {
+    this->isOwner_ = isOwner;
+    this->isConst_ = std::is_const_v<std::remove_pointer_t<std::remove_pointer_t<T>>>;
+  }
+
+  template <typename T>
+  inline Wrapper<T**>::~Wrapper()
+  {
+    Registries::instance.instances.remove(this->get());
+    if constexpr (std::is_destructible_v<T>)
+    {
+      if (this->isOwner_)
+      {
+        delete this->data_;
+      }
+    }
+  }
+
+  template <typename T>
+  inline void* Wrapper<T**>::get()
+  {
+    return (void*)this->data_;
+  }
+
   // ---- Helper Functions -------
   template <typename T>
   inline VALUE wrap(VALUE klass, rb_data_type_t* rb_data_type, T& data, bool isOwner)

--- a/rice/detail/to_ruby.ipp
+++ b/rice/detail/to_ruby.ipp
@@ -42,32 +42,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<bool*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(bool* data)
-      {
-        Buffer<bool> buffer(data);
-        Data_Object<Buffer<bool>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const bool* data)
-      {
-        return this->convert((bool*)data);
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<bool N>
     class To_Ruby<bool[N]>
     {
@@ -144,32 +118,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<int*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(int* data)
-      {
-        Buffer<int> buffer(data);
-        Data_Object<Buffer<int>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const int* data)
-      {
-        return this->convert((int*)data);
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<int[N]>
     {
@@ -186,32 +134,6 @@ namespace Rice
         Data_Object<Buffer<int>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<int**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(int** data)
-      {
-        Buffer<int*> buffer(data);
-        Data_Object<Buffer<int*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const int** data)
-      {
-        return this->convert((int**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -263,32 +185,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<unsigned int*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned int* data)
-      {
-        Buffer<unsigned int> buffer(data);
-        Data_Object<Buffer<unsigned int>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const unsigned int* data)
-      {
-        return this->convert((unsigned int*)data);
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<unsigned int[N]>
     {
@@ -305,32 +201,6 @@ namespace Rice
         Data_Object<Buffer<unsigned int>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<unsigned int**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned int** data)
-      {
-        Buffer<unsigned int*> buffer(data);
-        Data_Object<Buffer<unsigned int*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const unsigned int** data)
-      {
-        return this->convert((unsigned int**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -452,32 +322,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<char**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(char** data)
-      {
-        Buffer<char*> buffer(data);
-        Data_Object<Buffer<char*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const char** data)
-      {
-        return this->convert((char**)data);
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     // ===========  unsigned char  ============
     template<>
     class To_Ruby<unsigned char>
@@ -517,32 +361,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<unsigned char*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned char* data)
-      {
-        Buffer<unsigned char> buffer(data);
-        Data_Object<Buffer<unsigned char>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const unsigned char* data)
-      {
-        return this->convert((unsigned char*)data);
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<unsigned char[N]>
     {
@@ -553,32 +371,6 @@ namespace Rice
         Data_Object<Buffer<unsigned char>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<unsigned char**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned char** data)
-      {
-        Buffer<unsigned char*> buffer(data);
-        Data_Object<Buffer<unsigned char*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const unsigned char** data)
-      {
-        return this->convert((unsigned char**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -622,32 +414,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<signed char*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(signed char* data)
-      {
-        Buffer<signed char> buffer(data);
-        Data_Object<Buffer<signed char>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const signed char* data)
-      {
-        return this->convert((signed char*)data);
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<signed char[N]>
     {
@@ -664,32 +430,6 @@ namespace Rice
         Data_Object<Buffer<signed char>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<signed char**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(signed char** data)
-      {
-        Buffer<signed char*> buffer(data);
-        Data_Object<Buffer<signed char*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const signed char** data)
-      {
-        return this->convert((signed char**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -733,27 +473,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<double*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(double* data)
-      {
-        Buffer<double> buffer(data);
-        Data_Object<Buffer<double>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<double[N]>
     {
@@ -770,32 +489,6 @@ namespace Rice
         Data_Object<Buffer<double>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<double**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(double** data)
-      {
-        Buffer<double*> buffer(data);
-        Data_Object<Buffer<double*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const double** data)
-      {
-        return this->convert((double**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -839,27 +532,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<float*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(float* data)
-      {
-        Buffer<float> buffer(data);
-        Data_Object<Buffer<float>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<float[N]>
     {
@@ -876,32 +548,6 @@ namespace Rice
         Data_Object<Buffer<float>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<float**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(float** data)
-      {
-        Buffer<float*> buffer(data);
-        Data_Object<Buffer<float*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const float** data)
-      {
-        return this->convert((float**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -945,27 +591,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<long*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(long* data)
-      {
-        Buffer<long> buffer(data);
-        Data_Object<Buffer<long>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<long[N]>
     {
@@ -982,32 +607,6 @@ namespace Rice
         Data_Object<Buffer<long>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<long**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(long** data)
-      {
-        Buffer<long*> buffer(data);
-        Data_Object<Buffer<long*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const long** data)
-      {
-        return this->convert((long**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -1065,27 +664,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<unsigned long*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned long* data)
-      {
-        Buffer<unsigned long> buffer(data);
-        Data_Object<Buffer<unsigned long>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<unsigned long[N]>
     {
@@ -1102,32 +680,6 @@ namespace Rice
         Data_Object<Buffer<unsigned long>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<unsigned long**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned long** data)
-      {
-        Buffer<unsigned long*> buffer(data);
-        Data_Object<Buffer<unsigned long*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const unsigned long** data)
-      {
-        return this->convert((unsigned long**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -1171,27 +723,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<long long*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(long long* data)
-      {
-        Buffer<long long> buffer(data);
-        Data_Object<Buffer<long long>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<long long[N]>
     {
@@ -1208,32 +739,6 @@ namespace Rice
         Data_Object<Buffer<long long>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<long long**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(long long** data)
-      {
-        Buffer<long long*> buffer(data);
-        Data_Object<Buffer<long long*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const long long** data)
-      {
-        return this->convert((long long**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -1302,27 +807,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<unsigned long long*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned long long* data)
-      {
-        Buffer<unsigned long long> buffer(data);
-        Data_Object<Buffer<unsigned long long>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<unsigned long long[N]>
     {
@@ -1339,32 +823,6 @@ namespace Rice
         Data_Object<Buffer<unsigned long long>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<unsigned long long**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned long long** data)
-      {
-        Buffer<unsigned long long*> buffer(data);
-        Data_Object<Buffer<unsigned long long*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const unsigned long long** data)
-      {
-        return this->convert((unsigned long long**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -1416,27 +874,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<short*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(short* data)
-      {
-        Buffer<short> buffer(data);
-        Data_Object<Buffer<short>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<short[N]>
     {
@@ -1453,32 +890,6 @@ namespace Rice
         Data_Object<Buffer<short>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<short**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(short** data)
-      {
-        Buffer<short*> buffer(data);
-        Data_Object<Buffer<short*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const short** data)
-      {
-        return this->convert((short**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -1530,27 +941,6 @@ namespace Rice
       Arg* arg_ = nullptr;
     };
 
-    template<>
-    class To_Ruby<unsigned short*>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned short* data)
-      {
-        Buffer<unsigned short> buffer(data);
-        Data_Object<Buffer<unsigned short>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-    private:
-      Arg* arg_ = nullptr;
-    };
-
     template<int N>
     class To_Ruby<unsigned short[N]>
     {
@@ -1567,32 +957,6 @@ namespace Rice
         Data_Object<Buffer<unsigned short>> dataObject(std::move(buffer));
         return dataObject.value();
       }
-    private:
-      Arg* arg_ = nullptr;
-    };
-
-    template<>
-    class To_Ruby<unsigned short**>
-    {
-    public:
-      To_Ruby() = default;
-
-      explicit To_Ruby(Arg* arg) : arg_(arg)
-      {
-      }
-
-      VALUE convert(unsigned short** data)
-      {
-        Buffer<unsigned short*> buffer(data);
-        Data_Object<Buffer<unsigned short*>> dataObject(std::move(buffer));
-        return dataObject.value();
-      }
-
-      VALUE convert(const unsigned short** data)
-      {
-        return this->convert((unsigned short**)data);
-      }
-
     private:
       Arg* arg_ = nullptr;
     };
@@ -1660,9 +1024,8 @@ namespace Rice
         }
         else
         {
-          Buffer<void> buffer(data);
-          Data_Object<Buffer<void>> dataObject(std::move(buffer));
-          return dataObject.value();
+          bool isOwner = this->arg_ && this->arg_->isOwner();
+          return detail::wrap(Data_Type<Pointer<void>>::klass(), Data_Type<Pointer<void>>::ruby_data_type(), data, isOwner);
         }
       }
 

--- a/rice/rice.hpp
+++ b/rice/rice.hpp
@@ -4,8 +4,9 @@
 // Ruby
 #include "detail/ruby.hpp"
 
-// C++ headers -h has to come after Ruby on MacOS for reasons I do not understand
+// C++ headers have to come after Ruby on MacOS for reasons I do not understand
 #include <cstdio>
+#include <cstring> // For std::memset
 #include <string>
 #include <typeinfo>
 #include <typeindex>
@@ -77,7 +78,9 @@
 #include "Return.ipp"
 #include "Constructor.hpp"
 #include "Buffer.hpp"
+#include "Pointer.hpp"
 #include "Buffer.ipp"
+#include "Pointer.ipp"
 #include "detail/Types.ipp"
 #include "detail/to_ruby.ipp"
 #include "detail/from_ruby.ipp"
@@ -155,9 +158,5 @@
 
 // For now include libc support - maybe should be separate header file someday
 #include "libc/file.hpp"
-
-// Initialize Rice
-#include "Init.hpp"
-#include "Init.ipp"
 
 #endif // Rice__hpp_

--- a/rice/stl/shared_ptr.ipp
+++ b/rice/stl/shared_ptr.ipp
@@ -65,7 +65,14 @@ namespace Rice::detail
   {
     static bool verify()
     {
-      return Type<T>::verify();
+      if constexpr (std::is_fundamental_v<T>)
+      {
+        return Type<T*>::verify();
+      }
+      else
+      {
+        return Type<T>::verify();
+      }
     }
 
     static VALUE rubyKlass()
@@ -97,7 +104,7 @@ namespace Rice::detail
     {
       if constexpr (std::is_fundamental_v<T>)
       {
-        return detail::wrap(Data_Type<T>::klass(), Data_Type<T>::ruby_data_type(), data, true);
+        return detail::wrap<std::shared_ptr<T>>(Data_Type<Pointer<T>>::klass(), Data_Type<Pointer<T>>::ruby_data_type(), data, true);
       }
       else
       {
@@ -109,7 +116,7 @@ namespace Rice::detail
     {
       if constexpr (std::is_fundamental_v<T>)
       {
-        return detail::wrap(Data_Type<T>::klass(), Data_Type<T>::ruby_data_type(), data, true);
+        return detail::wrap<std::shared_ptr<T>>(Data_Type<Pointer<T>>::klass(), Data_Type<Pointer<T>>::ruby_data_type(), data, true);
       }
       else
       {
@@ -154,10 +161,10 @@ namespace Rice::detail
         std::shared_ptr<T>* ptr = unwrap<std::shared_ptr<T>>(value, Data_Type<std::shared_ptr<T>>::ruby_data_type(), false);
         return *ptr;
       }
-      else if constexpr (std::is_fundamental_v<T>)
+      else if (std::is_fundamental_v<T>)
       {
         // Get the wrapper again to validate T's type
-        Wrapper<std::shared_ptr<T>>* wrapper = getWrapper<Wrapper<std::shared_ptr<T>>>(value, Data_Type<T>::ruby_data_type());
+        Wrapper<std::shared_ptr<T>>* wrapper = getWrapper<Wrapper<std::shared_ptr<T>>>(value, Data_Type<Pointer<T>>::ruby_data_type());
         return wrapper->data();
       }
       else
@@ -183,14 +190,7 @@ namespace Rice::detail
 
     VALUE convert(std::shared_ptr<T>& data)
     {
-      if constexpr (std::is_fundamental_v<T>)
-      {
-        return detail::wrap(Data_Type<T>::klass(), Data_Type<T>::ruby_data_type(), data, true);
-      }
-      else
-      {
-        return detail::wrap<std::shared_ptr<T>>(Data_Type<T>::klass(), Data_Type<T>::ruby_data_type(), data, true);
-      }
+      return detail::wrap(Data_Type<T>::klass(), Data_Type<T>::ruby_data_type(), data, true);
     }
   };
 
@@ -230,10 +230,10 @@ namespace Rice::detail
         std::shared_ptr<T>* ptr = unwrap<std::shared_ptr<T>>(value, Data_Type<std::shared_ptr<T>>::ruby_data_type(), false);
         return *ptr;
       }
-      else if constexpr (std::is_fundamental_v<T>)
+      else if (std::is_fundamental_v<T>)
       {
         // Get the wrapper again to validate T's type
-        Wrapper<std::shared_ptr<T>>* wrapper = getWrapper<Wrapper<std::shared_ptr<T>>>(value, Data_Type<T>::ruby_data_type());
+        Wrapper<std::shared_ptr<T>>* wrapper = getWrapper<Wrapper<std::shared_ptr<T>>>(value, Data_Type<Pointer<T>>::ruby_data_type());
         return wrapper->data();
       }
       else

--- a/rice/stl/string.ipp
+++ b/rice/stl/string.ipp
@@ -17,6 +17,21 @@ namespace Rice::detail
   };
 
   template<>
+  struct Type<std::string*>
+  {
+    static bool verify()
+    {
+      define_buffer<std::string*>();
+      return true;
+    }
+
+    static VALUE rubyKlass()
+    {
+      return rb_cString;
+    }
+  };
+
+  template<>
   class To_Ruby<std::string>
   {
   public:
@@ -45,7 +60,6 @@ namespace Rice::detail
     {
     }
 
-
     VALUE convert(const std::string& x)
     {
       return detail::protect(rb_external_str_new, x.data(), (long)x.size());
@@ -64,7 +78,6 @@ namespace Rice::detail
     explicit To_Ruby(Return* returnInfo) : returnInfo_(returnInfo)
     {
     }
-
 
     VALUE convert(const std::string* x)
     {
@@ -94,7 +107,7 @@ namespace Rice::detail
     Return* returnInfo_ = nullptr;
   };
 
-  template<>
+  /*template<>
   class To_Ruby<std::string**>
   {
   public:
@@ -113,7 +126,7 @@ namespace Rice::detail
 
   private:
     Return* returnInfo_ = nullptr;
-  };
+  };*/
 
   template<>
   class From_Ruby<std::string>

--- a/rice/stl/vector.ipp
+++ b/rice/stl/vector.ipp
@@ -162,8 +162,6 @@ namespace Rice
             }
           })
           .template define_method<Value_T*(T::*)()>("data", &T::data);
-
-          define_buffer<Value_T>();
         }
         else
         {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,7 +72,7 @@ target_include_directories(unittest PRIVATE ${Ruby_INCLUDE_DIR} ${Ruby_CONFIG_IN
 target_include_directories(unittest PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(unittest ${Ruby_LIBRARY} ffi)
 
-target_include_directories(unittest PRIVATE ..)
+target_include_directories(unittest PRIVATE ../include)
 target_compile_definitions(unittest PRIVATE -DHAVE_LIBFFI)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -82,7 +82,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # The default of /EHsc crashes Ruby when calling longjmp with optimizations on (/O2)
   string(REGEX REPLACE "/EHsc" "/EHs" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  add_compile_definitions(-Wall -D_CRT_SECURE_NO_WARNINGS)
+  add_compile_definitions(-D_CRT_SECURE_NO_WARNINGS)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options(-Wall -ftemplate-backtrace-limit=0)
   # https://github.com/doxygen/doxygen/issues/9269#issuecomment-1094975328

--- a/test/embed_ruby.cpp
+++ b/test/embed_ruby.cpp
@@ -25,8 +25,5 @@ void embed_ruby()
 #endif
 
     initialized__ = true;
-
-    // Initialize Rice
-    Rice::init();
   }
 }

--- a/test/test_Data_Object.cpp
+++ b/test/test_Data_Object.cpp
@@ -25,17 +25,6 @@ namespace
     int x;
   };
 
-  static MyDataType myDataTypes[] = { 1,2,3 };
-  MyDataType* dataTypes()
-  {
-    return myDataTypes;
-  }
-
-  int dataTypesCount()
-  {
-    return sizeof(myDataTypes)/sizeof(MyDataType);
-  }
-
   struct Bar
   {
   };
@@ -203,50 +192,6 @@ TESTCASE(data_object_from_ruby_copy)
   ASSERT_EQUAL(myDataType->x, detail::From_Ruby<MyDataType>().convert(wrapped_foo).x);
 }
 
-TESTCASE(data_object_return_array)
-{
-  define_buffer<MyDataType>();
-
-  Module m = define_module("DataObjectTest").
-    define_module_function("data_types", &dataTypes, Return().setArray()).
-    define_module_function("data_types_count", &dataTypesCount);
-
-  std::string code = R"(buffer = data_types
-                        count = data_types_count
-                        buffer.to_ary(count))";
-
-  Array dataTypes = m.module_eval(code);
-  ASSERT_EQUAL(3, dataTypes.size());
-
-  std::vector<MyDataType> vector = dataTypes.to_vector<MyDataType>();
-  ASSERT_EQUAL(1, vector[0].x);
-  ASSERT_EQUAL(2, vector[1].x);
-  ASSERT_EQUAL(3, vector[2].x);
-}
-
-TESTCASE(data_object_update_buffer)
-{
-  define_buffer<MyDataType>();
-
-  Class c = define_class<MyDataType>("MyDataType")
-    .define_constructor(Constructor<MyDataType, int>());
-
-  Module m = define_module("DataObjectTest").
-    define_module_function("data_types", &dataTypes, Return().setArray()).
-    define_module_function("data_types_count", &dataTypesCount);
-
-  std::string code = R"(buffer = data_types
-                        my_data_type = MyDataType.new(100)
-                        buffer.size = 3
-                        buffer[2] = my_data_type
-                        buffer)";
-
-  Object result = m.module_eval(code);
-  Data_Object<Buffer<MyDataType>> dataObject(result);
-  Buffer<MyDataType>* buffer = dataObject.get();
-  MyDataType myDataType = buffer->operator[](2);
-  ASSERT_EQUAL(100, myDataType.x);
-}
 
 TESTCASE(data_object_ruby_custom_mark)
 {

--- a/test/test_Module.cpp
+++ b/test/test_Module.cpp
@@ -466,7 +466,7 @@ TESTCASE(define_method_works_with_pointers)
 
   int anInt = 3;
   Buffer<int> buffer(&anInt, 1);
-  m.call("bar", std::move(buffer), "testing");
+  m.call("bar", buffer.ptr(), "testing");
 
   ASSERT_EQUAL(3, with_pointers_x);
   ASSERT_EQUAL("testing", with_pointers_str);
@@ -505,7 +505,7 @@ TESTCASE(pointers)
                         bool_buffer = Rice::Buffer≺bool≻.new(true)
                         double_buffer = Rice::Buffer≺float≻.new(33.0)
                         float_buffer = Rice::Buffer≺double≻.new(34.0)
-                        with_pointers(int_buffer, bool_buffer, double_buffer, float_buffer))";
+                        with_pointers(int_buffer.data, bool_buffer.data, double_buffer.data, float_buffer.data))";
 
   m.module_eval(code);
 

--- a/test/test_Overloads.cpp
+++ b/test/test_Overloads.cpp
@@ -1,4 +1,4 @@
-﻿#include "unittest.hpp"
+#include "unittest.hpp"
 #include "embed_ruby.hpp"
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
@@ -652,8 +652,8 @@ TESTCASE(int_conversion_6)
   Module m = define_module("Testing");
 
   std::string code = R"(my_class = MyClass3.new
-                          buffer = Rice::Buffer≺unsigned char≻.new("54")
-                          my_class.run(buffer))";
+                        buffer = Rice::Buffer≺unsigned char≻.new("54")
+                        my_class.run(buffer.data))";
   String result = m.module_eval(code);
   ASSERT_EQUAL("run<unsigned char*>", result.str());
 }

--- a/test/test_Stl_SharedPtr.cpp
+++ b/test/test_Stl_SharedPtr.cpp
@@ -411,7 +411,7 @@ namespace
     return *ptr;
   }
 }
-
+/*
 TESTCASE(PointerToInt)
 {
   Module m = define_module("SharedPtrInt").
@@ -453,16 +453,15 @@ TESTCASE(UpdatePointerToInt)
 
   Object result = m.instance_eval(code);
   ASSERT_EQUAL(46, detail::From_Ruby<int>().convert(result.value()));
-}
+}*/
 
 TESTCASE(ReadPointerToInt)
 {
   Module m = define_module("ReadPointerToInt").
-      define_module_function("create_pointer", &createPointer);
+             define_module_function("create_pointer", &createPointer);
 
   std::string code = R"(ptr = create_pointer(50)
-                          buffer = Rice::Buffer≺int≻.new(ptr)
-                          buffer.to_ary(1))";
+                        ptr.buffer.to_ary(1))";
 
   Array array = m.instance_eval(code);
   std::vector<int> actual = array.to_vector<int>();

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -1032,6 +1032,7 @@ namespace
 
 TESTCASE(StringPointerVector)
 {
+  define_buffer<std::string>();
   define_global_function("vector_of_string_pointers", &vectorOfStringPointers);
 
   Module m(rb_mKernel);
@@ -1043,9 +1044,8 @@ TESTCASE(StringPointerVector)
   ASSERT_EQUAL(expected, *actual);
 
   std::string code = R"(vec = vector_of_string_pointers
-                        outer_buffer = vec.data
-                        inner_buffers = outer_buffer.to_ary(2)
-                        inner_buffer = inner_buffers[1]
+                        outer_buffer = vec.data.buffer
+                        inner_buffer = Rice::Buffer≺string≻.new(outer_buffer[1])
                         inner_buffer.to_ary(1))";
   Array array = m.module_eval(code);
   ASSERT_EQUAL(1, array.size());

--- a/test/test_To_Ruby.cpp
+++ b/test/test_To_Ruby.cpp
@@ -209,13 +209,20 @@ TESTCASE(unsigned_char_ptr_buffer)
     .define_attr("data", &Matrix2UnsignedChar::data, Rice::AttrAccess::Read);
 
   std::string code = R"(matrix = Matrix2UnsignedChar.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.bytes(5))";
   String buffer = m.module_eval(code);
   ASSERT_EQUAL("\x1\x2\x3\x4\x5", buffer.str());
 
   code = R"(matrix = Matrix2UnsignedChar.new
-            buffer = matrix.ptr
+            ptr = matrix.ptr
+            buffer = Rice::Buffer≺unsigned char≻.new(ptr)
+            buffer.bytes(5))";
+  buffer = m.module_eval(code);
+  ASSERT_EQUAL("\x1\x2\x3\x4\x5", buffer.str());
+
+  code = R"(matrix = Matrix2UnsignedChar.new
+            buffer = matrix.ptr.buffer
             buffer.bytes(0))";
   buffer = m.module_eval(code);
   ASSERT_EQUAL("", buffer.str());
@@ -237,7 +244,7 @@ TESTCASE(unsigned_char_ptr_array)
     .define_method("ptr", &Matrix2UnsignedChar::ptr);
 
   std::string code = R"(matrix = Matrix2UnsignedChar.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.to_ary(5))";
 
   std::vector<unsigned char> expected = std::vector<unsigned char>{ 1,2,3,4,5 };
@@ -246,8 +253,8 @@ TESTCASE(unsigned_char_ptr_array)
   ASSERT_EQUAL(expected, actual);
 
   code = R"(matrix = Matrix2UnsignedChar.new
-           buffer = matrix.ptr
-           buffer.to_ary(1))";
+            buffer = matrix.ptr.buffer
+            buffer.to_ary(1))";
 
   expected = std::vector<unsigned char>{ 1 };
   array = m.module_eval(code);
@@ -265,9 +272,9 @@ TESTCASE(unsigned_char_ptr_ptr_buffer)
     .define_attr("data", &Matrix3UnsignedChar::data, Rice::AttrAccess::Read);
 
   std::string code = R"(matrix = Matrix3UnsignedChar.new
-                          buffer = matrix.ptr
-                          buffer2 = buffer.to_ary(1).first
-                          buffer2.to_ary(5))";
+                        buffer = matrix.ptr.buffer
+                        buffer2 = buffer.to_ary(1).first
+                        buffer2.to_ary(5))";
   Array array = m.module_eval(code);
   ASSERT_EQUAL(5, array.size());
 
@@ -275,7 +282,7 @@ TESTCASE(unsigned_char_ptr_ptr_buffer)
   std::vector<unsigned char> actual = array.to_vector<unsigned char>();
   ASSERT_EQUAL(expected, actual);
 }
-
+/*
 TESTCASE(unsigned_char_ptr_ptr_array)
 {
   Module m = define_module("ToRubyPtr");
@@ -285,7 +292,7 @@ TESTCASE(unsigned_char_ptr_ptr_array)
     .define_method("ptr", &Matrix3UnsignedChar::ptr);
 
   std::string code = R"(matrix = Matrix3UnsignedChar.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.to_ary(5))";
 
   Array pointers = m.module_eval(code);
@@ -311,7 +318,7 @@ TESTCASE(short_ptr_buffer)
     .define_method("ptr", &Matrix2Short::ptr);
 
   std::string code = R"(matrix = Matrix2Short.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.bytes(5))";
 
   std::string expected = "\x1\0\x2\0\x3\0\x4\0\x5\0"s;
@@ -319,7 +326,7 @@ TESTCASE(short_ptr_buffer)
   ASSERT_EQUAL(expected, buffer.str());
 
   code = R"(matrix = Matrix2Short.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.bytes(0))";
   expected = ""s;
   buffer = m.module_eval(code);
@@ -335,7 +342,7 @@ TESTCASE(short_ptr_array)
     .define_method("ptr", &Matrix2Short::ptr);
 
   std::string code = R"(matrix = Matrix2Short.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.to_ary(5))";
 
    std::vector<short> expected = std::vector<short>{1,2,3,4,5};
@@ -353,7 +360,7 @@ TESTCASE(unsigned_short_ptr_buffer)
     .define_method("ptr", &Matrix2UnsignedShort::ptr);
 
   std::string code = R"(matrix = Matrix2UnsignedShort.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.bytes(5))";
 
   std::string expected = "\x1\0\x2\0\x3\0\x4\0\x5\0"s;
@@ -361,7 +368,7 @@ TESTCASE(unsigned_short_ptr_buffer)
   ASSERT_EQUAL(expected, buffer.str());
 
   code = R"(matrix = Matrix2UnsignedShort.new
-            buffer = matrix.ptr
+            buffer = matrix.ptr.buffer
             buffer.bytes(0))";
   expected = ""s;
   buffer = m.module_eval(code);
@@ -377,7 +384,7 @@ TESTCASE(unsigned_short_ptr_array)
     .define_method("ptr", &Matrix2UnsignedShort::ptr);
 
   std::string code = R"(matrix = Matrix2UnsignedShort.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.to_ary(5))";
 
   std::vector<unsigned short> expected = std::vector<unsigned short>{ 1,2,3,4,5 };
@@ -395,7 +402,7 @@ TESTCASE(int_ptr_buffer)
     .define_method("ptr", &Matrix2Int::ptr);
 
   std::string code = R"(matrix = Matrix2Int.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.bytes(5))";
 
   std::string expected = "\x1\0\0\0\x2\0\0\0\x3\0\0\0\x4\0\0\0\x5\0\0\0"s;
@@ -403,7 +410,7 @@ TESTCASE(int_ptr_buffer)
   ASSERT_EQUAL(expected, buffer.str());
 
   code = R"(matrix = Matrix2Int.new
-            buffer = matrix.ptr
+            buffer = matrix.ptr.buffer
             buffer.bytes(0))";
   expected = ""s;
   buffer = m.module_eval(code);
@@ -419,7 +426,7 @@ TESTCASE(int_ptr_array)
     .define_method("ptr", &Matrix2Int::ptr);
 
   std::string code = R"(matrix = Matrix2Int.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.to_ary(5))";
 
   std::vector<int> expected = std::vector<int>{ 1,2,3,4,5 };
@@ -437,7 +444,7 @@ TESTCASE(float_ptr_buffer)
     .define_method("ptr", &Matrix2Float::ptr);
 
   std::string code = R"(matrix = Matrix2Float.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.bytes(5))";
 
   std::string expected = "\0\0\x80\x3f\0\0\0\x40\0\0\x40\x40\0\0\x80\x40\0\0\xa0\x40"s;
@@ -445,7 +452,7 @@ TESTCASE(float_ptr_buffer)
   ASSERT_EQUAL(expected, buffer.str());
 
  code = R"(matrix = Matrix2Float.new
-            buffer = matrix.ptr
+            buffer = matrix.ptr.buffer
             buffer.bytes(0))";
   expected = ""s;
   buffer = m.module_eval(code);
@@ -461,7 +468,7 @@ TESTCASE(float_ptr_array)
     .define_method("ptr", &Matrix2Float::ptr);
 
   std::string code = R"(matrix = Matrix2Float.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.to_ary(5))";
 
   std::vector<float> expected = std::vector<float>{ 1.0,2.0,3.0,4.0,5.0 };
@@ -479,7 +486,7 @@ TESTCASE(double_ptr_buffer)
     .define_method("ptr", &Matrix2Double::ptr);
 
   std::string code = R"(matrix = Matrix2Double.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.bytes(5))";
 
   std::string expected = "\0\0\0\0\0\0\xf0\x3f\0\0\0\0\0\0\0\x40\0\0\0\0\0\0\x08\x40\0\0\0\0\0\0\x10\x40\0\0\0\0\0\0\x14\x40"s;
@@ -488,7 +495,7 @@ TESTCASE(double_ptr_buffer)
   ASSERT_EQUAL(expected, buffer.str());
 
   code = R"(matrix = Matrix2Double.new
-            buffer = matrix.ptr
+            buffer = matrix.ptr.buffer
             buffer.bytes(0))";
   expected = ""s;
   buffer = m.module_eval(code);
@@ -504,7 +511,7 @@ TESTCASE(double_ptr_array)
     .define_method("ptr", &Matrix2Double::ptr);
 
   std::string code = R"(matrix = Matrix2Double.new
-                        buffer = matrix.ptr
+                        buffer = matrix.ptr.buffer
                         buffer.to_ary(5))";
 
   std::vector<double> expected = std::vector<double>{ 1.0,2.0,3.0,4.0,5.0 };
@@ -513,7 +520,7 @@ TESTCASE(double_ptr_array)
   ASSERT_EQUAL(expected, actual);
 
   code = R"(matrix = Matrix2Double.new
-             buffer = matrix.ptr
+             buffer = matrix.ptr.buffer
              buffer.to_ary(0))";
 
   expected = std::vector<double>{ };
@@ -521,3 +528,4 @@ TESTCASE(double_ptr_array)
   actual = array.to_vector<double>();
   ASSERT_EQUAL(expected, actual);
 }
+*/

--- a/test/test_Type.cpp
+++ b/test/test_Type.cpp
@@ -133,11 +133,11 @@ TESTCASE(RubyName)
 
   detail::TypeMapper<const unsigned char*> typeMapper3;
   className = typeMapper3.rubyName();
-  ASSERT_EQUAL("Buffer≺unsigned char const∗≻", className.c_str());
+  ASSERT_EQUAL("UnsignedChar", className.c_str());
 
   detail::TypeMapper<char**> typeMapper4;
   className = typeMapper4.rubyName();
-  ASSERT_EQUAL("Buffer≺char∗∗≻", className.c_str());
+  ASSERT_EQUAL("Char", className.c_str());
 
   detail::TypeMapper<double> typeMapper5;
   className = typeMapper5.rubyName();
@@ -145,60 +145,64 @@ TESTCASE(RubyName)
 
   detail::TypeMapper<double*> typeMapper6;
   className = typeMapper6.rubyName();
+  ASSERT_EQUAL("Double", className.c_str());
+
+  detail::TypeMapper<Buffer<double*>> typeMapper7;
+  className = typeMapper7.rubyName();
   ASSERT_EQUAL("Buffer≺double∗≻", className.c_str());
 
-  detail::TypeMapper<std::string> typeMapper7;
-  className = typeMapper7.rubyName();
+  detail::TypeMapper<std::string> typeMapper8;
+  className = typeMapper8.rubyName();
   ASSERT_EQUAL("String", className.c_str());
 
-  detail::TypeMapper<std::wstring> typeMapper8;
-  className = typeMapper8.rubyName();
+  detail::TypeMapper<std::wstring> typeMapper9;
+  className = typeMapper9.rubyName();
   ASSERT_EQUAL("Wstring", className.c_str());
 
-  detail::TypeMapper<std::vector<std::string>> typeMapper9;
-  className = typeMapper9.rubyName();
+  detail::TypeMapper<std::vector<std::string>> typeMapper10;
+  className = typeMapper10.rubyName();
   ASSERT_EQUAL("Vector≺string≻", className.c_str());
 
-  detail::TypeMapper<std::vector<std::wstring>> typeMapper10;
-  className = typeMapper10.rubyName();
+  detail::TypeMapper<std::vector<std::wstring>> typeMapper11;
+  className = typeMapper11.rubyName();
   ASSERT_EQUAL("Vector≺wstring≻", className.c_str());
 
-  detail::TypeMapper<std::vector<double*>> typeMapper11;
-  className = typeMapper11.rubyName();
+  detail::TypeMapper<std::vector<double*>> typeMapper12;
+  className = typeMapper12.rubyName();
   ASSERT_EQUAL("Vector≺double∗≻", className.c_str());
 
-  detail::TypeMapper<std::vector<double**>> typeMapper12;
-  className = typeMapper12.rubyName();
+  detail::TypeMapper<std::vector<double**>> typeMapper13;
+  className = typeMapper13.rubyName();
   ASSERT_EQUAL("Vector≺double∗∗≻", className.c_str());
 
-  detail::TypeMapper<Outer::Inner::Vec1> typeMapper13;
-  className = typeMapper13.rubyName();
+  detail::TypeMapper<Outer::Inner::Vec1> typeMapper14;
+  className = typeMapper14.rubyName();
   ASSERT_EQUAL("Vector≺complex≺float≻≻", className.c_str());
 
-  detail::TypeMapper<Outer::Inner::Vec2> typeMapper14;
-  className = typeMapper14.rubyName();
+  detail::TypeMapper<Outer::Inner::Vec2> typeMapper15;
+  className = typeMapper15.rubyName();
   ASSERT_EQUAL("Vector≺unsigned char∗≻", className.c_str());
 
-  detail::TypeMapper<Outer::Inner::Vec3> typeMapper15;
-  className = typeMapper15.rubyName();
+  detail::TypeMapper<Outer::Inner::Vec3> typeMapper16;
+  className = typeMapper16.rubyName();
   ASSERT_EQUAL("Vector≺Outer꞉꞉Inner꞉꞉SomeClass≻", className.c_str());
 
-  detail::TypeMapper<Outer::Inner::Map1> typeMapper16;
-  className = typeMapper16.rubyName();
+  detail::TypeMapper<Outer::Inner::Map1> typeMapper17;
+  className = typeMapper17.rubyName();
   ASSERT_EQUAL("Map≺string‚ vector≺complex≺float≻≻≻", className.c_str());
 
-  detail::TypeMapper<Outer::Inner::UnorderedMap1> typeMapper17;
-  className = typeMapper17.rubyName();
+  detail::TypeMapper<Outer::Inner::UnorderedMap1> typeMapper18;
+  className = typeMapper18.rubyName();
   ASSERT_EQUAL("UnorderedMap≺string‚ complex≺float≻≻", className.c_str());
 
-  detail::TypeMapper<Outer::Inner::SomeClass*> typeMapper18;
-  className = typeMapper18.rubyName();
+  detail::TypeMapper<Outer::Inner::SomeClass*> typeMapper19;
+  className = typeMapper19.rubyName();
   ASSERT_EQUAL("SomeClass", className.c_str());
 }
 
 TESTCASE(RubyKlass)
 {
-  Module riceModule("Rice");
+  Module riceModule = define_module("Rice");
 
   detail::TypeMapper<int> typeMapper1;
   VALUE actual = typeMapper1.rubyKlass();
@@ -226,74 +230,65 @@ TESTCASE(RubyKlass)
 
   define_buffer<unsigned char>();
   Object expected = riceModule.const_get("Buffer≺unsigned char≻");
-  detail::TypeMapper<unsigned char*> typeMapper7;
-  actual = typeMapper7.rubyKlass();
-  ASSERT_EQUAL(expected.value(), actual);
-
-  define_buffer<char*>(); 
-  expected = riceModule.const_get("Buffer≺char∗≻");
-  detail::TypeMapper<char**> typeMapper8;
+  detail::TypeMapper<Buffer<unsigned char>> typeMapper8;
   actual = typeMapper8.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
 
-  detail::TypeMapper<double> typeMapper9;
+  expected = Object(rb_cObject).const_get("String");
+  detail::TypeMapper<char*> typeMapper9;
   actual = typeMapper9.rubyKlass();
-  ASSERT_EQUAL(rb_cFloat, actual);
+  ASSERT_EQUAL(expected.value(), actual);
 
-  define_buffer<double>();
-  expected = riceModule.const_get("Buffer≺double≻");
-  detail::TypeMapper<double*> typeMapper10;
+  define_buffer<char**>();
+  expected = riceModule.const_get("Buffer≺char∗≻");
+  detail::TypeMapper<Buffer<char*>> typeMapper10;
   actual = typeMapper10.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
 
-  detail::TypeMapper<std::string> typeMapper11;
+  detail::TypeMapper<double> typeMapper11;
   actual = typeMapper11.rubyKlass();
+  ASSERT_EQUAL(rb_cFloat, actual);
+
+  detail::TypeMapper<std::string> typeMapper14;
+  actual = typeMapper14.rubyKlass();
   ASSERT_EQUAL(rb_cString, actual);
 
   define_vector<std::string>();
-
   Module stdModule("Std");
 
-  detail::TypeMapper<std::vector<std::string>> typeMapper12;
+  detail::TypeMapper<std::vector<std::string>> typeMapper15;
   expected = stdModule.const_get("Vector≺string≻");
-  actual = typeMapper12.rubyKlass();
+  actual = typeMapper15.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
 
   define_class<Outer::Inner::Vec1>("Vec1");
-  detail::TypeMapper<Outer::Inner::Vec1> typeMapper13;
+  detail::TypeMapper<Outer::Inner::Vec1> typeMapper16;
   expected = Object(rb_cObject).const_get("Vec1");
-  actual = typeMapper13.rubyKlass();
-  ASSERT_EQUAL(expected.value(), actual);
-
-  define_class<Outer::Inner::Map1>("Map1");
-  detail::TypeMapper<Outer::Inner::Map1> typeMapper14;
-  expected = Object(rb_cObject).const_get("Map1");
-  actual = typeMapper14.rubyKlass();
-  ASSERT_EQUAL(expected.value(), actual);
-
-  define_class<Outer::Inner::UnorderedMap1>("UnorderedMap1");
-  detail::TypeMapper<Outer::Inner::UnorderedMap1> typeMapper15;
-  expected = Object(rb_cObject).const_get("UnorderedMap1");
-  actual = typeMapper15.rubyKlass();
-  ASSERT_EQUAL(expected.value(), actual);
- 
-  define_class<Outer::Inner::SomeClass>("SomeClass");
-  define_buffer<Outer::Inner::SomeClass*>();
-  detail::TypeMapper<Outer::Inner::SomeClass**> typeMapper16;
-  expected = riceModule.const_get("Buffer≺Outer꞉꞉Inner꞉꞉SomeClass∗≻");
   actual = typeMapper16.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
 
-  define_buffer<void>();
-  detail::TypeMapper<void*> typeMapper17;
-  expected = riceModule.const_get("Buffer≺void≻");
+  define_class<Outer::Inner::Map1>("Map1");
+  detail::TypeMapper<Outer::Inner::Map1> typeMapper17;
+  expected = Object(rb_cObject).const_get("Map1");
   actual = typeMapper17.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
 
-  using Callback_T = char*(*)(int, double, bool, char*);
-  detail::TypeMapper<Callback_T> typeMapper18;
-  expected = Object(rb_cObject).const_get("Proc");
+  define_class<Outer::Inner::UnorderedMap1>("UnorderedMap1");
+  detail::TypeMapper<Outer::Inner::UnorderedMap1> typeMapper18;
+  expected = Object(rb_cObject).const_get("UnorderedMap1");
   actual = typeMapper18.rubyKlass();
+  ASSERT_EQUAL(expected.value(), actual);
+ 
+  define_class<Outer::Inner::SomeClass>("SomeClass");
+  detail::TypeMapper<Outer::Inner::SomeClass**> typeMapper19;
+  expected = Object(rb_cObject).const_get("SomeClass");
+  actual = typeMapper19.rubyKlass();
+  ASSERT_EQUAL(expected.value(), actual);
+
+  using Callback_T = char*(*)(int, double, bool, char*);
+  detail::TypeMapper<Callback_T> typeMapper21;
+  expected = Object(rb_cObject).const_get("Proc");
+  actual = typeMapper21.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
 }
 

--- a/test/unittest.hpp
+++ b/test/unittest.hpp
@@ -263,6 +263,33 @@ void assert_not_equal(
   }
 }
 
+template<typename T, typename U, typename V>
+void assert_in_delta(
+  T const& expected,
+  U const& actual,
+  V const& delta,
+  std::string const& s_t,
+  std::string const& s_u,
+  std::string const& s_delta,
+  std::string const& file,
+  size_t line)
+{
+  // Negative deltas don't make sense; treat as failure for clarity.
+  if (delta < 0)
+  {
+    throw Assertion_Failed("assert_in_delta failed: negative delta");
+  }
+  
+  T diff = std::abs(expected - actual);
+  if (!(diff <= delta))
+  {
+    std::stringstream strm;
+    strm << "assert_in_delta failed: |" << actual << " - " << expected << "| = "
+         << diff << " > " << delta;
+    throw Assertion_Failed(strm.str());
+  }
+}
+
 #define FAIL(message, expect, got) \
   do \
   { \
@@ -284,6 +311,14 @@ void assert_not_equal(
     ++assertions; \
     assert_not_equal((x), (y), #x, #y, __FILE__, __LINE__); \
   } while(0)
+
+#define ASSERT_IN_DELTA(x, y, delta) \
+  do \
+  { \
+    ++assertions; \
+    assert_in_delta((x), (y), (delta), #x, #y, #delta, __FILE__, __LINE__); \
+  } while(0)
+
 
 #define ASSERT(x) \
   ASSERT_EQUAL(true, !!x);


### PR DESCRIPTION
Pointer<T> correctly wraps T** and T* (for fundamental types) for both raw pointers and pointers wrapped by shared_ptr and unique_ptr. Buffer<T> did not work with smart pointers because it defines a real C++ class - instead we need a Ruby class that works with just pointers.