### PR TITLE
Fix division by zero exception

### DIFF
--- a/include/rice/stl.hpp
+++ b/include/rice/stl.hpp
@@ -4099,7 +4099,7 @@ namespace Rice
           .define_method("max_size", &T::max_size)
           .define_method("reserve", &T::reserve)
           .define_method("size", &T::size);
-        
+
         rb_define_alias(klass_, "count", "size");
         rb_define_alias(klass_, "length", "size");
         //detail::protect(rb_define_alias, klass_, "count", "size");
@@ -4135,6 +4135,11 @@ namespace Rice
           })
           .define_method("[]", [this](T& vector, Difference_T index) -> std::optional<std::reference_wrapper<Value_T>>
           {
+            if (vector.size() == 0)
+            {
+              return std::nullopt;
+            }
+
             index = normalizeIndex(vector.size(), index);
             if (index < 0 || index >= (Difference_T)vector.size())
             {
@@ -4174,6 +4179,11 @@ namespace Rice
           })
           .define_method("[]", [this](T& vector, Difference_T index) -> std::optional<Value_T>
           {
+            if (vector.size() == 0)
+            {
+              return std::nullopt;
+            }
+
             index = normalizeIndex(vector.size(), index);
             if (index < 0 || index >= (Difference_T)vector.size())
             {
@@ -4188,6 +4198,11 @@ namespace Rice
 
         klass_.define_method("[]", [this](T& vector, Difference_T start, Difference_T length) -> VALUE
         {
+          if (vector.size() == 0)
+          {
+            return Qnil;
+          }
+
           start = normalizeIndex(vector.size(), start);
           if (start < 0 || start >= (Difference_T)vector.size())
           {
@@ -4299,7 +4314,11 @@ namespace Rice
           })
           .define_method("insert", [this](T& vector, Difference_T index, Parameter_T element) -> T&
           {
-            index = normalizeIndex(vector.size(), index, true);
+            if (vector.size() > 0) {
+                if (index != vector.size()) index = normalizeIndex(vector.size(), index, true);
+            } else {
+                if (index != 0) throw std::out_of_range("Invalid index: " + std::to_string(index));
+            }
             auto iter = vector.begin() + index;
             vector.insert(iter, std::move(element));
             return vector;
@@ -4330,7 +4349,11 @@ namespace Rice
         .define_method("shrink_to_fit", &T::shrink_to_fit)
         .define_method("[]=", [this](T& vector, Difference_T index, Parameter_T element) -> void
           {
-            index = normalizeIndex(vector.size(), index, true);
+            if (vector.size() > 0) {
+              index = normalizeIndex(vector.size(), index, true);
+            } else {
+              throw std::out_of_range("Invalid index: " + std::to_string(index));
+            }
             vector[index] = std::move(element);
           });
 

--- a/rice/stl/vector.ipp
+++ b/rice/stl/vector.ipp
@@ -115,7 +115,7 @@ namespace Rice
           .define_method("max_size", &T::max_size)
           .define_method("reserve", &T::reserve)
           .define_method("size", &T::size);
-        
+
         rb_define_alias(klass_, "count", "size");
         rb_define_alias(klass_, "length", "size");
         //detail::protect(rb_define_alias, klass_, "count", "size");
@@ -151,6 +151,11 @@ namespace Rice
           })
           .define_method("[]", [this](T& vector, Difference_T index) -> std::optional<std::reference_wrapper<Value_T>>
           {
+            if (vector.size() == 0)
+            {
+              return std::nullopt;
+            }
+
             index = normalizeIndex(vector.size(), index);
             if (index < 0 || index >= (Difference_T)vector.size())
             {
@@ -190,6 +195,11 @@ namespace Rice
           })
           .define_method("[]", [this](T& vector, Difference_T index) -> std::optional<Value_T>
           {
+            if (vector.size() == 0)
+            {
+              return std::nullopt;
+            }
+
             index = normalizeIndex(vector.size(), index);
             if (index < 0 || index >= (Difference_T)vector.size())
             {
@@ -204,6 +214,11 @@ namespace Rice
 
         klass_.define_method("[]", [this](T& vector, Difference_T start, Difference_T length) -> VALUE
         {
+          if (vector.size() == 0)
+          {
+            return Qnil;
+          }
+
           start = normalizeIndex(vector.size(), start);
           if (start < 0 || start >= (Difference_T)vector.size())
           {
@@ -315,7 +330,11 @@ namespace Rice
           })
           .define_method("insert", [this](T& vector, Difference_T index, Parameter_T element) -> T&
           {
-            index = normalizeIndex(vector.size(), index, true);
+            if (vector.size() > 0) {
+                if (index != vector.size()) index = normalizeIndex(vector.size(), index, true);
+            } else {
+                if (index != 0) throw std::out_of_range("Invalid index: " + std::to_string(index));
+            }
             auto iter = vector.begin() + index;
             vector.insert(iter, std::move(element));
             return vector;
@@ -346,7 +365,11 @@ namespace Rice
         .define_method("shrink_to_fit", &T::shrink_to_fit)
         .define_method("[]=", [this](T& vector, Difference_T index, Parameter_T element) -> void
           {
-            index = normalizeIndex(vector.size(), index, true);
+            if (vector.size() > 0) {
+              index = normalizeIndex(vector.size(), index, true);
+            } else {
+              throw std::out_of_range("Invalid index: " + std::to_string(index));
+            }
             vector[index] = std::move(element);
           });
 

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -148,6 +148,23 @@ TESTCASE(Empty)
 
   result = vec.call("last");
   ASSERT_EQUAL(Qnil, result.value());
+
+  result = vec.call("[]", 0);
+  ASSERT_EQUAL(Qnil, result.value());
+
+  vec.call("insert", 0, 11);
+  result = vec.call("first");
+  ASSERT_EQUAL(11, detail::From_Ruby<int32_t>().convert(result));
+
+  vec.call("insert", 1, 13);
+  result = vec.call("last");
+  ASSERT_EQUAL(13, detail::From_Ruby<int32_t>().convert(result));
+
+  vec.call("clear");
+  ASSERT_EXCEPTION_CHECK(
+    Exception,
+    result = vec.call("[]=", 0, 7),
+    ASSERT_EQUAL("Invalid index: 0", ex.what()));
 }
 
 TESTCASE(BoolVector)
@@ -199,7 +216,7 @@ TESTCASE(Indexing)
   vec.call("push", 0);
   vec.call("push", 1);
   vec.call("push", 2);
-  
+
   Object result = vec.call("size");
   ASSERT_EQUAL(3, detail::From_Ruby<int32_t>().convert(result));
 
@@ -470,7 +487,7 @@ TESTCASE(NotDefaultConstructable)
 {
   define_class<NotComparable>("NotComparable").
     define_constructor(Constructor<NotComparable, uint32_t>());
-    
+
   Class c = define_vector<NotComparable>("NotComparableVector");
   Object vec = c.call("new");
 
@@ -529,7 +546,7 @@ TESTCASE(Comparable)
   Class c = define_vector<Comparable>("ComparableVector");
 
   Object vec = c.call("new");
-  
+
   Comparable comparable1(1);
   vec.call("push", comparable1);
 
@@ -719,7 +736,7 @@ TESTCASE(DefaultValue)
 TESTCASE(ToArray)
 {
   Module m = define_module("Testing");
-  
+
   Class c = define_vector<std::string>("StringVector").
     define_constructor(Constructor<std::vector<std::string>>());
 


### PR DESCRIPTION
- `#[]`, `#insert`, `#[]=`: method `Vector#normalizeIndex` requires `Vector#size > 0` when using **negative** index,otherwise the program will crash, therefore check `Vector#size` first.
- `#insert`: instead of raise an exception, but append element to vector, when `index == Vector#size` 