### PR TITLE
Fix encoding issue, Closes #321

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -9471,7 +9471,7 @@ namespace Rice::detail
       else if (natives.size() == 0)
       {
         Identifier identifier(methodId);
-        rb_raise(rb_eArgError, "Could not find method call for %s#%s", rb_class2name(klass), identifier.c_str());
+        rb_enc_raise(rb_utf8_encoding(), rb_eArgError, "Could not find method call for %s#%s", rb_class2name(klass), identifier.c_str());
       }
       else
       {
@@ -9537,7 +9537,7 @@ namespace Rice::detail
               message << "\n     " << resolve.native->toString();
             }
 
-            rb_raise(rb_eArgError, message.str().c_str(), rb_class2name(klass), identifier.c_str(), natives.size());
+            rb_enc_raise(rb_utf8_encoding(), rb_eArgError, message.str().c_str(), rb_class2name(klass), identifier.c_str(), natives.size());
           }
         }
       }

--- a/rice/detail/Native.ipp
+++ b/rice/detail/Native.ipp
@@ -79,7 +79,7 @@ namespace Rice::detail
       else if (natives.size() == 0)
       {
         Identifier identifier(methodId);
-        rb_raise(rb_eArgError, "Could not find method call for %s#%s", rb_class2name(klass), identifier.c_str());
+        rb_enc_raise(rb_utf8_encoding(), rb_eArgError, "Could not find method call for %s#%s", rb_class2name(klass), identifier.c_str());
       }
       else
       {
@@ -145,7 +145,7 @@ namespace Rice::detail
               message << "\n     " << resolve.native->toString();
             }
 
-            rb_raise(rb_eArgError, message.str().c_str(), rb_class2name(klass), identifier.c_str(), natives.size());
+            rb_enc_raise(rb_utf8_encoding(), rb_eArgError, message.str().c_str(), rb_class2name(klass), identifier.c_str(), natives.size());
           }
         }
       }

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -691,6 +691,24 @@ TESTCASE(AutoRegisterParameter)
   ASSERT_EQUAL(complexes[1], std::complex<double>(5, 5));
 }
 
+TESTCASE(AutoRegisterException)
+{
+  std::string code = R"(
+    begin
+      Std::Vector≺complex≺double≻≻.new('!!!!')
+    rescue => e
+      name = e.class.name
+      "#{e.class.name} #{e.message} #{(e.backtrace || []).join("\n")}"  # shoud not raise 'incompatible character encodings: BINARY (ASCII-8BIT) and UTF-8' ?
+    end
+    "reachable! - #{name}"
+  )";
+
+  Module m = define_module("Testing");
+  Object result = m.module_eval(code);
+  std::string actual = detail::From_Ruby<std::string>().convert(result);
+  ASSERT_EQUAL("reachable! - ArgumentError", actual);
+}
+
 namespace
 {
   std::vector<std::string> defaultVector(std::vector<std::string> strings = {"one", "two", "three"})


### PR DESCRIPTION
- Use `rb_enc_raise` instead of `rb_raise` when exception message contains klass name
- Add testcase `AutoRegisterException`