### PR TITLE
Fix vector negative index issue

### DIFF
--- a/include/rice/stl.hpp
+++ b/include/rice/stl.hpp
@@ -4099,7 +4099,7 @@ namespace Rice
           .define_method("max_size", &T::max_size)
           .define_method("reserve", &T::reserve)
           .define_method("size", &T::size);
-        
+
         rb_define_alias(klass_, "count", "size");
         rb_define_alias(klass_, "length", "size");
         //detail::protect(rb_define_alias, klass_, "count", "size");
@@ -4299,7 +4299,12 @@ namespace Rice
           })
           .define_method("insert", [this](T& vector, Difference_T index, Parameter_T element) -> T&
           {
-            index = normalizeIndex(vector.size(), index, true);
+            if (index < 0) {
+                index = index + vector.size() + 1;
+                if (index < 0) throw std::out_of_range("index " + std::to_string(index - 1 - vector.size()) + " too small for array; minimum: -" + std::to_string(vector.size() + 1));
+            } else if (index > (Difference_T)vector.size()) {
+                throw std::out_of_range("index " + std::to_string(index) + " too big");
+            }
             auto iter = vector.begin() + index;
             vector.insert(iter, std::move(element));
             return vector;

--- a/rice/stl/vector.ipp
+++ b/rice/stl/vector.ipp
@@ -115,7 +115,7 @@ namespace Rice
           .define_method("max_size", &T::max_size)
           .define_method("reserve", &T::reserve)
           .define_method("size", &T::size);
-        
+
         rb_define_alias(klass_, "count", "size");
         rb_define_alias(klass_, "length", "size");
         //detail::protect(rb_define_alias, klass_, "count", "size");
@@ -315,7 +315,12 @@ namespace Rice
           })
           .define_method("insert", [this](T& vector, Difference_T index, Parameter_T element) -> T&
           {
-            index = normalizeIndex(vector.size(), index, true);
+            if (index < 0) {
+                index = index + vector.size() + 1;
+                if (index < 0) throw std::out_of_range("index " + std::to_string(index - 1 - vector.size()) + " too small for array; minimum: -" + std::to_string(vector.size() + 1));
+            } else if (index > (Difference_T)vector.size()) {
+                throw std::out_of_range("index " + std::to_string(index) + " too big");
+            }
             auto iter = vector.begin() + index;
             vector.insert(iter, std::move(element));
             return vector;

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -369,6 +369,20 @@ TESTCASE(Modify)
 
   result = vec.call("pop");
   ASSERT_EQUAL(Qnil, result.value());
+
+  vec.call("append", 10);
+  vec.call("append", 20);
+  vec.call("insert", -1, 30);
+  result = vec.call("to_s");
+  ASSERT_EQUAL("[10, 20, 30]", detail::From_Ruby<std::string>().convert(result));
+
+  vec.call("insert", 3, 40);
+  result = vec.call("to_s");
+  ASSERT_EQUAL("[10, 20, 30, 40]", detail::From_Ruby<std::string>().convert(result));
+
+  vec.call("insert", 0, 0);
+  result = vec.call("to_s");
+  ASSERT_EQUAL("[0, 10, 20, 30, 40]", detail::From_Ruby<std::string>().convert(result));
 }
 
 TESTCASE(Clone)


### PR DESCRIPTION
**FIX**:

- `#[]`, `#[]=`, `#insert`: Handle divide by 0 to avoid app crash when using negative index
- `#insert`: Use correct negative index, now we can insert item at `-1`

----

**BREAKCHANGE**:

- `#insert`: will raise an error if negative index too small

----

**NOTE**:

- `#[]`, `#[]=`: Still allow negative indices wrap around cuz do not want to break previous behaviors.
