### PR TITLE
Align Ruby and C++ Vector indexing

### DIFF
--- a/rice/stl/vector.ipp
+++ b/rice/stl/vector.ipp
@@ -38,9 +38,8 @@ namespace Rice
       // Helper method to translate Ruby indices to vector indices
       Difference_T normalizeIndex(Size_T size, Difference_T index, bool enforceBounds = false)
       {
-        // Negative indices mean count from the right. Note that negative indices
-        // wrap around!
-        if (index < 0)
+        // Negative indices mean count from the right
+        if (index < 0 && (-index <= size))
         {
           index = ((-index) % size);
           index = index > 0 ? size - index : index;

--- a/test/test_Stl_Vector.cpp
+++ b/test/test_Stl_Vector.cpp
@@ -225,10 +225,30 @@ TESTCASE(Indexing)
   ASSERT_EQUAL(0, detail::From_Ruby<int32_t>().convert(result));
 
   result = vec.call("[]", -4);
-  ASSERT_EQUAL(2, detail::From_Ruby<int32_t>().convert(result));
+  ASSERT_EQUAL(Qnil, result.value());
 
   result = vec.call("[]", -7);
-  ASSERT_EQUAL(2, detail::From_Ruby<int32_t>().convert(result));
+  ASSERT_EQUAL(Qnil, result.value());
+}
+
+TESTCASE(IndexingEmptyVector)
+{
+  Module m = define_module("Testing");
+
+  Class c = define_vector<std::int32_t>("IntVector");
+  Object vec = c.call("new");
+
+  Object result = vec.call("size");
+  ASSERT_EQUAL(0, detail::From_Ruby<int32_t>().convert(result));
+
+  result = vec.call("[]", 0);
+  ASSERT_EQUAL(Qnil, result.value());
+
+  result = vec.call("[]", 1);
+  ASSERT_EQUAL(Qnil, result.value());
+
+  result = vec.call("[]", -1);
+  ASSERT_EQUAL(Qnil, result.value());
 }
 
 TESTCASE(Slice)


### PR DESCRIPTION
Mimic Ruby's behavior to return nil for negative index values that are larger than an Array's size. Also fix negative indexes for zero length vectors. See https://github.com/ruby-rice/rice/pull/320.