### PR TITLE
Fix symbol arguments for Rice 4.7.0

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -12742,6 +12742,12 @@ namespace Rice::detail
   class From_Ruby<Symbol>
   {
   public:
+    From_Ruby() = default;
+
+    explicit From_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     Convertible is_convertible(VALUE value)
     {
       switch (rb_type(value))
@@ -12761,6 +12767,9 @@ namespace Rice::detail
     {
       return Symbol(value);
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 }
 

--- a/rice/cpp_api/Symbol.ipp
+++ b/rice/cpp_api/Symbol.ipp
@@ -104,6 +104,12 @@ namespace Rice::detail
   class From_Ruby<Symbol>
   {
   public:
+    From_Ruby() = default;
+
+    explicit From_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     Convertible is_convertible(VALUE value)
     {
       switch (rb_type(value))
@@ -123,5 +129,8 @@ namespace Rice::detail
     {
       return Symbol(value);
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 }

--- a/test/test_Symbol.cpp
+++ b/test/test_Symbol.cpp
@@ -73,3 +73,15 @@ TESTCASE(to_id)
   Symbol symbol("Foo");
   ASSERT_EQUAL(Identifier("Foo"), symbol.to_id());
 }
+
+namespace
+{
+  void testSymbolArg(Object self, Symbol string)
+  {
+  }
+}
+
+TESTCASE(use_symbol_in_wrapped_function)
+{
+  define_global_function("test_symbol_arg", &testSymbolArg);
+}


### PR DESCRIPTION
Symbol arguments generate a compiler error with Rice 4.7.0.

```
/Users/user/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rice-4.7.0/include/rice/rice.hpp:12742:9: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'Arg *' to 'const From_Ruby<Symbol>' for 1st argument
 12742 |   class From_Ruby<Symbol>
       |         ^~~~~~~~~
/Users/user/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rice-4.7.0/include/rice/rice.hpp:12742:9: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'Arg *' to 'From_Ruby<Symbol>' for 1st argument
 12742 |   class From_Ruby<Symbol>
       |         ^~~~~~~~~
/Users/user/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/rice-4.7.0/include/rice/rice.hpp:12742:9: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 1 was provided
```