### PR TITLE
Update docs for `Array#push` for Rice 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Breaking Changes:
    ```
 * You can no longer pass a Buffer<T> to an API that takes a pointer. Instead use Buffer<T>#data or Buffer<T>::release
 * The Rice_Init method has been removed.
+* Array#push requires a second argument.
 
 ## 4.6.1 (2025-06-25)
 * Improve attribute handling. Correctly deal with non-copyable/assignable attributes and return references instead of copies of objects

--- a/doc/cpp_api/overview.rst
+++ b/doc/cpp_api/overview.rst
@@ -34,9 +34,9 @@ would iterate over an STL container:
 .. code-block:: cpp
 
   Array a;
-  a.push(detail::To_Ruby<int>().convert(42));
-  a.push(detail::To_Ruby<int>().convert(43));
-  a.push(detail::To_Ruby<int>().convert(44));
+  a.push(detail::To_Ruby<int>().convert(42), false);
+  a.push(detail::To_Ruby<int>().convert(43), false);
+  a.push(detail::To_Ruby<int>().convert(44), false);
   Array::iterator it = a.begin();
   Array::iterator end = a.end();
   for(; it != end; ++it)

--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -1885,8 +1885,8 @@ namespace Rice
    *  Example:
    *  \code
    *    Array a;
-   *    a.push(String("some string"));
-   *    a.push(42);
+   *    a.push(String("some string"), false);
+   *    a.push(42, false);
    *  \endcode
    */
   class Array

--- a/rice/cpp_api/Array.hpp
+++ b/rice/cpp_api/Array.hpp
@@ -12,8 +12,8 @@ namespace Rice
    *  Example:
    *  \code
    *    Array a;
-   *    a.push(String("some string"));
-   *    a.push(42);
+   *    a.push(String("some string"), false);
+   *    a.push(42, false);
    *  \endcode
    */
   class Array


### PR DESCRIPTION
- Adds the second argument to docs
- Adds to the list of breaking changes in the changelog