### PR TITLE
Fix Ruby warnings with `Rbs` class

### DIFF
--- a/lib/rice/rbs.rb
+++ b/lib/rice/rbs.rb
@@ -53,7 +53,7 @@ module Rice
 									 "attr_reader"
 								 else
 									 "attr_writer"
-									end
+								 end
 			"#{attr_type} #{native_attributes.first.name}: #{native_attributes.first.return_type}"
 		end
 
@@ -82,7 +82,7 @@ module Rice
 		end
 
 		def template
-			content = <<~EOS
+			<<~EOS
         module <%= klass.name.split("::")[0..-2].join("::") %>
           class <%= klass.name.split("::").last %>
           <%- native_functions.each do |name, functions| -%>


### PR DESCRIPTION
When Ruby warnings are enabled, it outputs:

```text
rice-4.7.0/lib/rice/rbs.rb:56: warning: mismatched indentations at 'end' with 'else' at 54
rice-4.7.0/lib/rice/rbs.rb:85: warning: assigned but unused variable - content
```