### PR TITLE
Fix `std::string_view` return values for Rice 4.7.0

### DIFF
--- a/include/rice/stl.hpp
+++ b/include/rice/stl.hpp
@@ -445,20 +445,38 @@ namespace Rice::detail
   class To_Ruby<std::string_view>
   {
   public:
+    To_Ruby() = default;
+
+    explicit To_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     VALUE convert(std::string_view const& x)
     {
       return detail::protect(rb_external_str_new, x.data(), (long)x.size());
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 
   template<>
   class To_Ruby<std::string_view&>
   {
   public:
+    To_Ruby() = default;
+
+    explicit To_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     VALUE convert(std::string_view const& x)
     {
       return detail::protect(rb_external_str_new, x.data(), (long)x.size());
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 
   template<>

--- a/rice/stl/string_view.ipp
+++ b/rice/stl/string_view.ipp
@@ -20,20 +20,38 @@ namespace Rice::detail
   class To_Ruby<std::string_view>
   {
   public:
+    To_Ruby() = default;
+
+    explicit To_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     VALUE convert(std::string_view const& x)
     {
       return detail::protect(rb_external_str_new, x.data(), (long)x.size());
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 
   template<>
   class To_Ruby<std::string_view&>
   {
   public:
+    To_Ruby() = default;
+
+    explicit To_Ruby(Arg* arg) : arg_(arg)
+    {
+    }
+
     VALUE convert(std::string_view const& x)
     {
       return detail::protect(rb_external_str_new, x.data(), (long)x.size());
     }
+
+  private:
+    Arg* arg_ = nullptr;
   };
 
   template<>

--- a/test/test_Stl_String_View.cpp
+++ b/test/test_Stl_String_View.cpp
@@ -91,3 +91,13 @@ TESTCASE(std_string_view_from_ruby_refefence)
   string.instance_eval("self[1] = 'a'");
   //ASSERT_EQUAL("tast", view);
 }
+
+namespace {
+  std::string_view testStringViewReturn(Object self) {
+    return "test";
+  }
+}
+
+TESTCASE(use_string_view_in_wrapped_function) {
+  define_global_function("test_string_view_return", &testStringViewReturn);
+}


### PR DESCRIPTION
`std::string_view` return values generate a compiler error with Rice 4.7.0.

```text
include/rice/stl.hpp:445:9: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'Return *' to 'const To_Ruby<std::string_view>' for 1st argument
  445 |   class To_Ruby<std::string_view>
      |         ^~~~~~~
include/rice/stl.hpp:445:9: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'Return *' to 'To_Ruby<std::string_view>' for 1st argument
  445 |   class To_Ruby<std::string_view>
      |         ^~~~~~~
include/rice/stl.hpp:445:9: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 1 was provided
```