### PR TITLE
Make second parameter optional for `Array#push`

### DIFF
--- a/include/rice/rice.hpp
+++ b/include/rice/rice.hpp
@@ -1965,7 +1965,7 @@ namespace Rice
      *  \return the object which was pushed onto the array.
      */
     template<typename T>
-    Object push(T&& obj, bool takeOwnership);
+    Object push(T&& obj, bool takeOwnership = false);
 
     //! Pop an element from the end of the array
     /*! \return the object which was popped from the array, or Qnil if

--- a/rice/cpp_api/Array.hpp
+++ b/rice/cpp_api/Array.hpp
@@ -92,7 +92,7 @@ namespace Rice
      *  \return the object which was pushed onto the array.
      */
     template<typename T>
-    Object push(T&& obj, bool takeOwnership);
+    Object push(T&& obj, bool takeOwnership = false);
 
     //! Pop an element from the end of the array
     /*! \return the object which was popped from the array, or Qnil if


### PR DESCRIPTION
For better backwards compatibility and a friendlier API.

Ref: #333 