### PR TITLE
Remove `ostruct` runtime dependency

### DIFF
--- a/bin/rice-doc.rb
+++ b/bin/rice-doc.rb
@@ -5,7 +5,6 @@ require_relative '../lib/rice'
 require_relative '../lib/rice/doc'
 
 # Now setup option parser
-require 'ostruct'
 require 'optparse'
 
 module Rice
@@ -51,7 +50,7 @@ module Rice
 		end
 
 		def parse_args
-			@options = OpenStruct.new
+			@options = Struct.new(:exec, :extension, :output).new
 			options.extension = nil
 			options.output = nil
 

--- a/bin/rice-rbs.rb
+++ b/bin/rice-rbs.rb
@@ -6,7 +6,6 @@ require 'bundler/setup'
 require 'rice'
 
 # Now setup option parser
-require 'ostruct'
 require 'optparse'
 
 module Rice
@@ -52,7 +51,7 @@ module Rice
 		end
 
 		def parse_args
-			@options = OpenStruct.new
+			@options = Struct.new(:exec, :extension, :output).new
 			options.extension = nil
 			options.output = nil
 

--- a/rice.gemspec
+++ b/rice.gemspec
@@ -67,7 +67,6 @@ Ruby extensions with C++ easier.
   ]
 
   s.required_ruby_version = ">= 3.1"
-  s.add_dependency "ostruct"
   s.add_development_dependency "bundler"
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"


### PR DESCRIPTION
Rice 4.7.0 adds a runtime dependency on `ostruct`, which includes it in all applications that use Rice.

This can be removed by using a `Struct` instead.