### PR TITLE
Make the member function global to reduce code size.

### DIFF
--- a/rice/detail/Native.hpp
+++ b/rice/detail/Native.hpp
@@ -73,10 +73,16 @@ namespace Rice::detail
     template<typename Parameter_Tuple, typename Arg_Tuple, size_t I>
     static void verify_parameter();
 
-  protected:
+  public:
     std::unique_ptr<Return> returnInfo_;
     std::vector<std::unique_ptr<ParameterAbstract>> parameters_;
   };
+
+  // Throw an exception when wrapper cannot be extracted
+  [[noreturn]] void Native_noWrapper(const VALUE klass, const std::string& wrapper, const std::string& method_name_);
+
+  // Do we need to keep alive any arguments?
+  void Native_checkKeepAlive(VALUE self, VALUE returnValue, std::vector<std::optional<VALUE>>& rubyValues, const std::string& method_name_, Native* parent_);
 }
 
 #endif // Rice__detail__Native__hpp_

--- a/rice/detail/NativeFunction.hpp
+++ b/rice/detail/NativeFunction.hpp
@@ -69,12 +69,6 @@ namespace Rice::detail
     template<typename std::size_t...I>
     Parameter_Ts getNativeValues(std::vector<std::optional<VALUE>>& values, std::index_sequence<I...>& indices);
 
-    // Throw an exception when wrapper cannot be extracted
-    [[noreturn]] void noWrapper(const VALUE klass, const std::string& wrapper);
-
-    // Do we need to keep alive any arguments?
-    void checkKeepAlive(VALUE self, VALUE returnValue, std::vector<std::optional<VALUE>>& rubyValues);
-
     // Call the underlying C++ function
     VALUE invoke(Parameter_Ts&& nativeArgs);
     VALUE invokeNoGVL(Parameter_Ts&& nativeArgs);

--- a/rice/detail/NativeFunction.ipp
+++ b/rice/detail/NativeFunction.ipp
@@ -133,65 +133,6 @@ namespace Rice::detail
   }
 
   template<typename Function_T, bool NoGVL>
-  void NativeFunction<Function_T, NoGVL>::noWrapper(const VALUE klass, const std::string& wrapper)
-  {
-    std::stringstream message;
-
-    message << "When calling the method `";
-    message << this->method_name_;
-    message << "' we could not find the wrapper for the '";
-    message << rb_obj_classname(klass);
-    message << "' ";
-    message << wrapper;
-    message << " type. You should not use keepAlive() on a Return or Arg that is a builtin Rice type.";
-
-    throw std::runtime_error(message.str());
-  }
-
-  template<typename Function_T, bool NoGVL>
-  void NativeFunction<Function_T, NoGVL>::checkKeepAlive(VALUE self, VALUE returnValue, std::vector<std::optional<VALUE>>& rubyValues)
-  {
-    // Self will be Qnil for wrapped procs
-    if (self == Qnil)
-      return;
-
-    // selfWrapper will be nullptr if this(self) is a builtin type and not an external(wrapped) type
-    // it is highly unlikely that keepAlive is used in this case but we check anyway
-    WrapperBase* selfWrapper = getWrapper(self);
-
-    // Check function arguments
-    for (size_t i = 0; i < this->parameters_.size(); i++)
-    {
-      Arg* arg = parameters_[i]->arg();
-      if (arg->isKeepAlive())
-      {
-        if (selfWrapper == nullptr)
-        {
-          noWrapper(self, "self");
-        }
-        selfWrapper->addKeepAlive(rubyValues[i].value());
-      }
-    }
-
-    // Check return value
-    if (this->returnInfo_->isKeepAlive())
-    {
-      if (selfWrapper == nullptr)
-      {
-        noWrapper(self, "self");
-      }
-
-      // returnWrapper will be nullptr if returnValue is a built-in type and not an external(wrapped) type
-      WrapperBase* returnWrapper = getWrapper(returnValue);
-      if (returnWrapper == nullptr)
-      {
-        noWrapper(returnValue, "return");
-      }
-      returnWrapper->addKeepAlive(self);
-    }
-  }
-
-  template<typename Function_T, bool NoGVL>
   VALUE NativeFunction<Function_T, NoGVL>::operator()(size_t argc, const VALUE* argv, VALUE self)
   {
     // Get the ruby values and make sure we have the correct number
@@ -214,7 +155,7 @@ namespace Rice::detail
     }
 
     // Check if any function arguments or return values need to have their lifetimes tied to the receiver
-    this->checkKeepAlive(self, result, rubyValues);
+    Native_checkKeepAlive(self, result, rubyValues, this->method_name_, this);
 
     return result;
   }

--- a/rice/detail/NativeMethod.hpp
+++ b/rice/detail/NativeMethod.hpp
@@ -75,12 +75,6 @@ namespace Rice::detail
     // Figure out what self is
     Receiver_T getReceiver(VALUE self);
 
-    // Throw an exception when wrapper cannot be extracted
-    [[noreturn]] void noWrapper(const VALUE klass, const std::string& wrapper);
-
-    // Do we need to keep alive any arguments?
-    void checkKeepAlive(VALUE self, VALUE returnValue, std::vector<std::optional<VALUE>>& rubyValues);
-
     // Call the underlying C++ method
     VALUE invoke(VALUE self, Apply_Args_T&& nativeArgs);
     VALUE invokeNoGVL(VALUE self, Apply_Args_T&& nativeArgs);

--- a/rice/detail/NativeMethod.ipp
+++ b/rice/detail/NativeMethod.ipp
@@ -225,65 +225,6 @@ namespace Rice::detail
   }
 
   template<typename Class_T, typename Method_T, bool NoGVL>
-  inline void NativeMethod<Class_T, Method_T, NoGVL>::noWrapper(const VALUE klass, const std::string& wrapper)
-  {
-    std::stringstream message;
-
-    message << "When calling the method `";
-    message << this->method_name_;
-    message << "' we could not find the wrapper for the '";
-    message << rb_obj_classname(klass);
-    message << "' ";
-    message << wrapper;
-    message << " type. You should not use keepAlive() on a Return or Arg that is a builtin Rice type.";
-
-    throw std::runtime_error(message.str());
-  }
-
-  template<typename Class_T, typename Method_T, bool NoGVL>
-  void NativeMethod<Class_T, Method_T, NoGVL>::checkKeepAlive(VALUE self, VALUE returnValue, std::vector<std::optional<VALUE>>& rubyValues)
-  {
-    // Self will be Qnil for wrapped procs
-    if (self == Qnil)
-      return;
-
-    // selfWrapper will be nullptr if this(self) is a builtin type and not an external(wrapped) type
-    // it is highly unlikely that keepAlive is used in this case but we check anyway
-    WrapperBase* selfWrapper = getWrapper(self);
-
-    // Check method arguments
-    for (size_t i=0; i<this->parameters_.size(); i++)
-    {
-      Arg* arg = parameters_[i]->arg();
-      if (arg->isKeepAlive())
-      {
-        if (selfWrapper == nullptr)
-        {
-          noWrapper(self, "self");
-        }
-        selfWrapper->addKeepAlive(rubyValues[i].value());
-      }
-    }
-
-    // Check return value
-    if (this->returnInfo_->isKeepAlive())
-    {
-      if (selfWrapper == nullptr)
-      {
-        noWrapper(self, "self");
-      }
-
-      // returnWrapper will be nullptr if returnValue is a built-in type and not an external(wrapped) type
-      WrapperBase* returnWrapper = getWrapper(returnValue);
-      if (returnWrapper == nullptr)
-      {
-        noWrapper(returnValue, "return");
-      }
-      returnWrapper->addKeepAlive(self);
-    }
-  }
-
-  template<typename Class_T, typename Method_T, bool NoGVL>
   VALUE NativeMethod<Class_T, Method_T, NoGVL>::operator()(size_t argc, const VALUE* argv, VALUE self)
   {
     // Get the ruby values and make sure we have the correct number
@@ -303,7 +244,7 @@ namespace Rice::detail
     }
 
     // Check if any method arguments or return values need to have their lifetimes tied to the receiver
-    this->checkKeepAlive(self, result, rubyValues);
+    Native_checkKeepAlive(self, result, rubyValues, this->method_name_, this);
 
     return result;
   }

--- a/rice/detail/Type.hpp
+++ b/rice/detail/Type.hpp
@@ -44,17 +44,18 @@ namespace Rice::detail
     std::string simplifiedName();
     std::string rubyName();
     VALUE rubyKlass();
-
-    // public only for testing
-    std::string findGroup(std::string& string, size_t start = 0);
   private:
     std::string demangle(char const* mangled_name);
     std::string rubyTypeName();
-    void removeGroup(std::string& string, std::regex regex);
-    void replaceGroup(std::string& string, std::regex regex, std::string replacement);
-    void replaceAll(std::string& string, std::regex regex, std::string replacement);
-    void capitalizeHelper(std::string& content, std::regex& regex);
   };
+
+  std::string TypeMapper_findGroup(std::string& string, size_t start = 0);
+  void TypeMapper_replaceAll(std::string& string, std::regex regex, std::string replacement);
+  void TypeMapper_removeGroup(std::string& string, std::regex regex);
+  void TypeMapper_replaceGroup(std::string& string, std::regex regex, std::string replacement);
+  void TypeMapper_simplifiedName(std::string& base);
+  void TypeMapper_capitalizeHelper(std::string& content, std::regex& regex);
+  void TypeMapper_rubyName(std::string& base, bool is_fundamental_v_intrinsic_type);
 
   template<typename T>
   void verifyType();

--- a/test/test_Type.cpp
+++ b/test/test_Type.cpp
@@ -42,18 +42,18 @@ TESTCASE(FindGroup)
   std::string name = "class std::vector<class cv::Vec<unsigned char, 2>, class std::allocator<class cv::Vec<unsigned char, 2> > >";
 
   detail::TypeMapper<int> typeMapper;
-  std::string group = typeMapper.findGroup(name, 0);
+  std::string group = Rice::detail::TypeMapper_findGroup(name, 0);
   ASSERT_EQUAL("<class cv::Vec<unsigned char, 2>, class std::allocator<class cv::Vec<unsigned char, 2> > >", group.c_str());
 
-  group = typeMapper.findGroup(name, 18);
+  group = Rice::detail::TypeMapper_findGroup(name, 18);
   ASSERT_EQUAL("<unsigned char, 2>", group.c_str());
-  
-  group = typeMapper.findGroup(name, 49);
+
+  group = Rice::detail::TypeMapper_findGroup(name, 49);
   ASSERT_EQUAL("<class cv::Vec<unsigned char, 2> >", group.c_str());
 
   ASSERT_EXCEPTION_CHECK(
     std::runtime_error,
-    typeMapper.findGroup(name, 48),
+    Rice::detail::TypeMapper_findGroup(name, 48),
       ASSERT_EQUAL("Unbalanced Group", ex.what())
   );
 }
@@ -288,7 +288,7 @@ TESTCASE(RubyKlass)
   expected = riceModule.const_get("Pointer≺string∗≻");
   actual = typeMapper18.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
-  
+
   define_vector<std::string>();
   Module stdModule("Std");
 
@@ -314,7 +314,7 @@ TESTCASE(RubyKlass)
   expected = Object(rb_cObject).const_get("UnorderedMap1");
   actual = typeMapper22.rubyKlass();
   ASSERT_EQUAL(expected.value(), actual);
- 
+
   define_class<Outer::Inner::SomeClass>("SomeClass");
   detail::TypeMapper<Outer::Inner::SomeClass**> typeMapper23;
   expected = Object(rb_cObject).const_get("SomeClass");
@@ -362,9 +362,9 @@ TESTCASE(MakeRubyClass)
 
   Identifier id(rubyClassName);
   define_class_under<Outer::Inner::Vec1>(module, id);
-  
+
   std::string code = R"(Testing.constants.grep(/Vector/).sort)";
-  
+
   Array result = module.module_eval(code);
   ASSERT_EQUAL(1, result.size());
 


### PR DESCRIPTION
- Use latest rice libaray [19925be](https://github.com/ruby-rice/rice/commit/19925bec9d2b6123d810abc85be2fd49f453f1e5)
- Compile [ruby-qt6](https://github.com/souk4711/ruby-qt6/tree/main) with options `-Os -fno-fast-math`

|                                           | before  | after   |   
|-------------------------------------------|---------|---------|
| qtcore/lib/qt6/qtcore/qtcore.so           | 42 MB   | 31MB    |  
| qtgui/lib/qt6/qtgui/qtgui.so              | 35 MB   | 25MB    | 
| qtwidgets/lib/qt6/qtwidgets/qtwidgets.so  | 73 MB   | 53MB    | 