### PR TITLE
Add Data_Type<T>::declare_class_under

### DIFF
--- a/rice/Data_Type.hpp
+++ b/rice/Data_Type.hpp
@@ -86,7 +86,7 @@ namespace Rice
     //! Register a Director class for this class.
     /*! For any class that uses Rice::Director to enable polymorphism
      *  across the languages, you need to register that director proxy
-     *  class with this method. Not doing so will cause the resulting 
+     *  class with this method. Not doing so will cause the resulting
      *  library to die at run time when it tries to convert the base
      *  type into the Director proxy type.
      *
@@ -118,7 +118,7 @@ namespace Rice
     static void unbind();
 
     static bool is_descendant(VALUE value);
-  
+
     //! Define an iterator.
     /*! Essentially this is a conversion from a C++-style begin/end
      *  iterator to a Ruby-style \#each iterator.
@@ -135,7 +135,7 @@ namespace Rice
 
     template <typename Attribute_T, typename...Arg_Ts>
     Data_Type<T>& define_attr(std::string name, Attribute_T attribute, AttrAccess access = AttrAccess::ReadWrite, const Arg_Ts&...args);
-  
+
     template <typename Attribute_T, typename...Arg_Ts>
     Data_Type<T>& define_singleton_attr(std::string name, Attribute_T attribute, AttrAccess access = AttrAccess::ReadWrite, const Arg_Ts&...args);
 
@@ -149,7 +149,7 @@ namespace Rice
      *  \return *this
      */
     template <typename Base_T = void>
-    static Data_Type<T> bind(const Module& klass);
+    static Data_Type<T> bind(const Module& klass, rb_data_type_t *data_type = nullptr);
 
     template<typename T_, typename Base_T>
     friend Rice::Data_Type<T_> define_class_under(Object parent, Identifier id, Class superKlass);
@@ -159,6 +159,9 @@ namespace Rice
 
     template<typename T_, typename Base_T>
     friend Rice::Data_Type<T_> define_class(char const * name);
+
+    template<typename T_, typename Base_T>
+    friend Rice::Data_Type<T_> declare_class_under(Object parent, char const* name, rb_data_type_t *data_type);
 
     template<typename Method_T, typename...Arg_Ts>
     void wrap_native_method(VALUE klass, std::string name, Method_T&& function, const Arg_Ts&...args);
@@ -179,7 +182,7 @@ namespace Rice
   };
 
   //! Define a new data class in the namespace given by module.
-  /*! This override allows you to specify a Ruby class as the base class versus a 
+  /*! This override allows you to specify a Ruby class as the base class versus a
    *  wrapped C++ class. This functionality is rarely needed - but is essential for
    *  creating new custom Exception classes where the Ruby superclass should be
    *  rb_eStandard
@@ -213,6 +216,13 @@ namespace Rice
    */
   template<typename T, typename Base_T = void>
   Data_Type<T> define_class(char const* name);
+
+  //! Identical to define_class_under, except it use an existed RTypedData.
+  /*! This allows you to bind the Data_Type<T> instance in every DLL on Win32
+   *  to the same RTypedData, see [issue#355](https://github.com/ruby-rice/rice/issues/355).
+   */
+  template<typename T, typename Base_T = void>
+  Data_Type<T> declare_class_under(Object parent, char const* name, rb_data_type_t *data_type);
 }
 
 #endif // Rice__Data_Type__hpp_


### PR DESCRIPTION
- Update Data_Type<T>::bind, add argument `rb_data_type_t*`
- Add Data_Type<T>::declare_class_under

----

This allows you to bind the Data_Type<T> instance in every DLL on Win32 to the same RTypedData, see [issue#355](https://github.com/ruby-rice/rice/issues/355).