### PR TITLE
Add opt-in Ractor-safe InstanceRegistry via RICE_RACTOR_SAFE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New Features
+
+* Add opt-in Ractor-safe `InstanceRegistry` via `RICE_RACTOR_SAFE` define. When enabled, a `std::recursive_mutex` protects all mutable registry operations, allowing C extensions built with Rice to be used safely from multiple Ruby Ractors (Ruby 3.4.x). Without the define, behavior is unchanged.
+
 ## 4.11.4 (2026-03-13)
 
 ### Bug Fixes

--- a/docs/why_rice.md
+++ b/docs/why_rice.md
@@ -74,7 +74,24 @@ Rice automatically converts common exceptions and provides a mechanism for conve
 
 ## Thread Safety
 
-Rice provides no mechanisms for dealing with thread safety. Many common thread safety issues should be alleviated by YARV, which supports POSIX threads.
+Rice provides no mechanisms for dealing with thread safety by default. Many common thread safety issues should be alleviated by YARV, which supports POSIX threads.
+
+### Ractor Support (opt-in)
+
+Ruby 3.4 introduced Ractors for true parallel execution. C extensions can declare themselves Ractor-safe via `rb_ext_ractor_safe(true)`, but Rice's internal `InstanceRegistry` — a `std::map` that tracks C++ object wrappers — is not thread-safe. Concurrent access from multiple Ractors corrupts the map, causing segfaults or hangs.
+
+To enable Ractor-safe operation, define `RICE_RACTOR_SAFE` before compilation:
+
+```ruby
+# In your extconf.rb:
+$CXXFLAGS << " -DRICE_RACTOR_SAFE"
+```
+
+This adds a `std::recursive_mutex` to `InstanceRegistry`, protecting all `lookup`, `add`, `remove`, and `clear` operations. Only `InstanceRegistry` requires this protection — the other Rice registries (`TypeRegistry`, `NativeRegistry`, `HandlerRegistry`, `ModuleRegistry`) are written once during initialization and are read-only at runtime.
+
+Without the define, the generated code is identical to the current Rice — no mutex, no overhead, no behavior change.
+
+**Compatibility:** Tested with Ruby 3.4.x Ractors. Ruby 4.x compatibility is pending validation.
 
 ## C++ Based API
 

--- a/rice/detail/InstanceRegistry.hpp
+++ b/rice/detail/InstanceRegistry.hpp
@@ -3,6 +3,10 @@
 
 #include <type_traits>
 
+#ifdef RICE_RACTOR_SAFE
+#include <mutex>
+#endif
+
 namespace Rice::detail
 {
   class InstanceRegistry
@@ -30,6 +34,9 @@ namespace Rice::detail
   private:
     bool shouldTrack(bool isOwner) const;
 
+#ifdef RICE_RACTOR_SAFE
+    std::recursive_mutex mutex_;
+#endif
     std::map<void*, VALUE> objectMap_;
   };
 } // namespace Rice::detail

--- a/rice/detail/InstanceRegistry.ipp
+++ b/rice/detail/InstanceRegistry.ipp
@@ -5,6 +5,10 @@ namespace Rice::detail
   template <typename T>
   inline VALUE InstanceRegistry::lookup(T* cppInstance, bool isOwner)
   {
+#ifdef RICE_RACTOR_SAFE
+    std::lock_guard lock(mutex_);
+#endif
+
     if (!this->shouldTrack(isOwner))
     {
       return Qnil;
@@ -17,6 +21,10 @@ namespace Rice::detail
   template <typename T>
   inline void InstanceRegistry::add(T* cppInstance, VALUE rubyInstance, bool isOwner)
   {
+#ifdef RICE_RACTOR_SAFE
+    std::lock_guard lock(mutex_);
+#endif
+
     if (!this->shouldTrack(isOwner))
     {
       return;
@@ -27,11 +35,17 @@ namespace Rice::detail
 
   inline void InstanceRegistry::remove(void* cppInstance)
   {
+#ifdef RICE_RACTOR_SAFE
+    std::lock_guard lock(mutex_);
+#endif
     this->objectMap_.erase(cppInstance);
   }
 
   inline void InstanceRegistry::clear()
   {
+#ifdef RICE_RACTOR_SAFE
+    std::lock_guard lock(mutex_);
+#endif
     this->objectMap_.clear();
   }
 

--- a/test/ruby/ext/extconf.rb
+++ b/test/ruby/ext/extconf.rb
@@ -1,0 +1,9 @@
+require "mkmf-rice"
+
+# Use the local Rice source (with RICE_RACTOR_SAFE support)
+rice_dir = File.expand_path("../../../../rice", __dir__)
+$INCFLAGS.prepend("-I#{rice_dir} ")
+
+$CXXFLAGS << " -DRICE_RACTOR_SAFE"
+
+create_makefile("ractor_test_ext")

--- a/test/ruby/ext/ractor_test_ext.cpp
+++ b/test/ruby/ext/ractor_test_ext.cpp
@@ -1,0 +1,54 @@
+// Minimal Rice extension for testing Ractor safety.
+// Compiled with -DRICE_RACTOR_SAFE to enable mutex-protected InstanceRegistry.
+
+#include <rice/rice.hpp>
+#include <rice/stl.hpp>
+
+#include <vector>
+
+namespace {
+  class Counter {
+  public:
+    Counter(int start) : value_(start) {}
+    int value() const { return value_; }
+    void increment() { value_++; }
+  private:
+    int value_;
+  };
+
+  // Object with an expensive constructor — spends significant time inside
+  // Rice's InstanceRegistry add/lookup cycle, widening the window for
+  // concurrent access from multiple Ractors.
+  class HeavyObject {
+  public:
+    HeavyObject(int size) {
+      data_.resize(size);
+      for (int i = 0; i < size; i++) {
+        data_[i] = i * i;
+      }
+    }
+
+    int sum() const {
+      int s = 0;
+      for (auto v : data_) { s += v; }
+      return s;
+    }
+
+  private:
+    std::vector<int> data_;
+  };
+}
+
+extern "C"
+void Init_ractor_test_ext() {
+  rb_ext_ractor_safe(true);
+
+  Rice::define_class<Counter>("Counter")
+    .define_constructor(Rice::Constructor<Counter, int>())
+    .define_method("value", &Counter::value)
+    .define_method("increment", &Counter::increment);
+
+  Rice::define_class<HeavyObject>("HeavyObject")
+    .define_constructor(Rice::Constructor<HeavyObject, int>())
+    .define_method("sum", &HeavyObject::sum);
+}

--- a/test/ruby/ext_unsafe/extconf.rb
+++ b/test/ruby/ext_unsafe/extconf.rb
@@ -1,0 +1,10 @@
+require "mkmf-rice"
+
+# Use the local Rice source — but WITHOUT RICE_RACTOR_SAFE.
+# The InstanceRegistry will have no mutex protection.
+rice_dir = File.expand_path("../../../../rice", __dir__)
+$INCFLAGS.prepend("-I#{rice_dir} ")
+
+# Intentionally NO -DRICE_RACTOR_SAFE
+
+create_makefile("ractor_test_unsafe_ext")

--- a/test/ruby/ext_unsafe/ractor_test_unsafe_ext.cpp
+++ b/test/ruby/ext_unsafe/ractor_test_unsafe_ext.cpp
@@ -1,0 +1,51 @@
+// Same extension as ractor_test_ext but compiled WITHOUT -DRICE_RACTOR_SAFE.
+// Used to verify that concurrent Ractor access segfaults without the mutex.
+
+#include <rice/rice.hpp>
+#include <rice/stl.hpp>
+
+#include <vector>
+
+namespace {
+  class Counter {
+  public:
+    Counter(int start) : value_(start) {}
+    int value() const { return value_; }
+    void increment() { value_++; }
+  private:
+    int value_;
+  };
+
+  class HeavyObject {
+  public:
+    HeavyObject(int size) {
+      data_.resize(size);
+      for (int i = 0; i < size; i++) {
+        data_[i] = i * i;
+      }
+    }
+
+    int sum() const {
+      int s = 0;
+      for (auto v : data_) { s += v; }
+      return s;
+    }
+
+  private:
+    std::vector<int> data_;
+  };
+}
+
+extern "C"
+void Init_ractor_test_unsafe_ext() {
+  rb_ext_ractor_safe(true);
+
+  Rice::define_class<Counter>("Counter")
+    .define_constructor(Rice::Constructor<Counter, int>())
+    .define_method("value", &Counter::value)
+    .define_method("increment", &Counter::increment);
+
+  Rice::define_class<HeavyObject>("HeavyObject")
+    .define_constructor(Rice::Constructor<HeavyObject, int>())
+    .define_method("sum", &HeavyObject::sum);
+}

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -1,0 +1,155 @@
+require "minitest/autorun"
+
+# Build the test extension if needed
+ext_dir = File.expand_path("ext", __dir__)
+bundle = File.join(ext_dir, "ractor_test_ext.bundle")
+so = File.join(ext_dir, "ractor_test_ext.so")
+
+unless File.exist?(bundle) || File.exist?(so)
+  Dir.chdir(ext_dir) do
+    system(RbConfig.ruby, "extconf.rb", exception: true)
+    system("make", "clean", exception: true)
+    system("make", exception: true)
+  end
+end
+
+$LOAD_PATH.unshift(ext_dir)
+require "ractor_test_ext"
+
+class RactorSafetyTest < Minitest::Test
+  def test_single_ractor
+    r = Ractor.new do
+      c = Counter.new(10)
+      c.increment
+      c.increment
+      c.value
+    end
+
+    assert_equal 12, r.take
+  end
+
+  def test_sequential_ractors
+    results = 5.times.map do |i|
+      r = Ractor.new(i) do |start|
+        c = Counter.new(start)
+        c.increment
+        c.value
+      end
+      r.take
+    end
+
+    assert_equal [1, 2, 3, 4, 5], results
+  end
+
+  def test_concurrent_ractors
+    r1 = Ractor.new do
+      c = Counter.new(100)
+      c.increment
+      c.value
+    end
+
+    r2 = Ractor.new do
+      c = Counter.new(200)
+      c.increment
+      c.value
+    end
+
+    assert_equal 101, r1.take
+    assert_equal 201, r2.take
+  end
+
+  def test_many_objects_in_ractor
+    r = Ractor.new do
+      counters = 50.times.map { |i| Counter.new(i) }
+      counters.each(&:increment)
+      counters.map(&:value)
+    end
+
+    result = r.take
+    assert_equal 50, result.size
+    assert_equal 50.times.map { |i| i + 1 }, result
+  end
+
+  def test_main_thread_and_ractor
+    main_counter = Counter.new(0)
+    main_counter.increment
+
+    r = Ractor.new do
+      c = Counter.new(1000)
+      c.increment
+      c.value
+    end
+
+    assert_equal 1, main_counter.value
+    assert_equal 1001, r.take
+  end
+
+  # --- Heavy concurrency test ---
+  #
+  # Calibrates HeavyObject constructor to take ~1 second, then launches
+  # two Ractors creating objects simultaneously. Each new() spends ~1s
+  # inside Rice's InstanceRegistry, making concurrent collisions certain.
+  # Without RICE_RACTOR_SAFE this would segfault.
+
+  TARGET_SECONDS = 1.0
+  OBJECTS_PER_RACTOR = 3
+
+  def test_concurrent_heavy_objects
+    size = calibrate_heavy_object_size
+
+    r1 = Ractor.new(size) do |sz|
+      OBJECTS_PER_RACTOR.times.map { HeavyObject.new(sz).sum }
+    end
+
+    r2 = Ractor.new(size) do |sz|
+      OBJECTS_PER_RACTOR.times.map { HeavyObject.new(sz).sum }
+    end
+
+    results1 = r1.take
+    results2 = r2.take
+
+    assert_equal OBJECTS_PER_RACTOR, results1.size
+    assert_equal OBJECTS_PER_RACTOR, results2.size
+
+    # All sums must be identical (same size → same computation)
+    expected_sum = results1.first
+    (results1 + results2).each do |s|
+      assert_equal expected_sum, s
+    end
+  end
+
+  private
+
+  # Find the size parameter that makes HeavyObject.new take ~TARGET_SECONDS.
+  # Uses exponential search then binary refinement.
+  def calibrate_heavy_object_size
+    # Exponential search for upper bound
+    size = 1_000
+    loop do
+      elapsed = measure_seconds { HeavyObject.new(size) }
+      break if elapsed >= TARGET_SECONDS
+      size *= 2
+    end
+
+    # Binary search between size/2 and size
+    lo = size / 2
+    hi = size
+    while hi - lo > lo / 10  # ~10% precision is enough
+      mid = (lo + hi) / 2
+      elapsed = measure_seconds { HeavyObject.new(mid) }
+      if elapsed < TARGET_SECONDS
+        lo = mid
+      else
+        hi = mid
+      end
+    end
+
+    (lo + hi) / 2
+  end
+
+  def measure_seconds
+    t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - t
+  end
+end

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -84,60 +84,75 @@ class RactorSafetyTest < Minitest::Test
     assert_equal 1001, r.take
   end
 
-  # --- Heavy concurrency test ---
+  # --- Heavy concurrency tests ---
   #
-  # Calibrates HeavyObject constructor to take ~1 second, then launches
-  # two Ractors creating objects simultaneously. Each new() spends ~1s
-  # inside Rice's InstanceRegistry, making concurrent collisions certain.
-  # Without RICE_RACTOR_SAFE this would segfault.
+  # Two strategies to maximize InstanceRegistry contention:
+  #
+  # 1. Few heavy objects: each HeavyObject.new takes ~1s, so the thread
+  #    spends a long time inside Rice's wrapping code per object.
+  #
+  # 2. Many fast objects: calibrate how many Counter.new fit in ~1s,
+  #    then create that many concurrently — thousands of rapid-fire
+  #    registry writes overlapping between Ractors.
 
-  TARGET_SECONDS = 1.0
-  OBJECTS_PER_RACTOR = 3
+  HEAVY_TARGET_SECONDS = 1.0
+  HEAVY_OBJECTS_PER_RACTOR = 3
+  FAST_TARGET_SECONDS = 1.0
 
   def test_concurrent_heavy_objects
     size = calibrate_heavy_object_size
 
     r1 = Ractor.new(size) do |sz|
-      OBJECTS_PER_RACTOR.times.map { HeavyObject.new(sz).sum }
+      HEAVY_OBJECTS_PER_RACTOR.times.map { HeavyObject.new(sz).sum }
     end
 
     r2 = Ractor.new(size) do |sz|
-      OBJECTS_PER_RACTOR.times.map { HeavyObject.new(sz).sum }
+      HEAVY_OBJECTS_PER_RACTOR.times.map { HeavyObject.new(sz).sum }
     end
 
     results1 = r1.take
     results2 = r2.take
 
-    assert_equal OBJECTS_PER_RACTOR, results1.size
-    assert_equal OBJECTS_PER_RACTOR, results2.size
+    assert_equal HEAVY_OBJECTS_PER_RACTOR, results1.size
+    assert_equal HEAVY_OBJECTS_PER_RACTOR, results2.size
 
-    # All sums must be identical (same size → same computation)
     expected_sum = results1.first
-    (results1 + results2).each do |s|
-      assert_equal expected_sum, s
+    (results1 + results2).each { |s| assert_equal expected_sum, s }
+  end
+
+  def test_concurrent_many_fast_objects
+    count = calibrate_fast_object_count
+
+    r1 = Ractor.new(count) do |n|
+      n.times { Counter.new(0) }
+      :ok
     end
+
+    r2 = Ractor.new(count) do |n|
+      n.times { Counter.new(0) }
+      :ok
+    end
+
+    assert_equal :ok, r1.take
+    assert_equal :ok, r2.take
   end
 
   private
 
-  # Find the size parameter that makes HeavyObject.new take ~TARGET_SECONDS.
-  # Uses exponential search then binary refinement.
+  # Find the size parameter that makes HeavyObject.new take ~1 second.
   def calibrate_heavy_object_size
-    # Exponential search for upper bound
     size = 1_000
     loop do
       elapsed = measure_seconds { HeavyObject.new(size) }
-      break if elapsed >= TARGET_SECONDS
+      break if elapsed >= HEAVY_TARGET_SECONDS
       size *= 2
     end
 
-    # Binary search between size/2 and size
     lo = size / 2
     hi = size
-    while hi - lo > lo / 10  # ~10% precision is enough
+    while hi - lo > lo / 10
       mid = (lo + hi) / 2
-      elapsed = measure_seconds { HeavyObject.new(mid) }
-      if elapsed < TARGET_SECONDS
+      if measure_seconds { HeavyObject.new(mid) } < HEAVY_TARGET_SECONDS
         lo = mid
       else
         hi = mid
@@ -145,6 +160,16 @@ class RactorSafetyTest < Minitest::Test
     end
 
     (lo + hi) / 2
+  end
+
+  # Find how many Counter.new(0) fit in ~1 second.
+  def calibrate_fast_object_count
+    count = 1_000
+    loop do
+      elapsed = measure_seconds { count.times { Counter.new(0) } }
+      return count if elapsed >= FAST_TARGET_SECONDS
+      count *= 2
+    end
   end
 
   def measure_seconds

--- a/test/ruby/test_ractor_unsafe.rb
+++ b/test/ruby/test_ractor_unsafe.rb
@@ -1,0 +1,85 @@
+require "minitest/autorun"
+
+# Build the UNSAFE test extension if needed (no RICE_RACTOR_SAFE)
+ext_dir = File.expand_path("ext_unsafe", __dir__)
+bundle = File.join(ext_dir, "ractor_test_unsafe_ext.bundle")
+so = File.join(ext_dir, "ractor_test_unsafe_ext.so")
+
+unless File.exist?(bundle) || File.exist?(so)
+  Dir.chdir(ext_dir) do
+    system(RbConfig.ruby, "extconf.rb", exception: true)
+    system("make", "clean", exception: true)
+    system("make", exception: true)
+  end
+end
+
+class RactorUnsafeTest < Minitest::Test
+  # Verify that WITHOUT RICE_RACTOR_SAFE, concurrent Ractor access to
+  # Rice-wrapped objects fails — either by crashing (segfault/abort) or
+  # by hanging (corrupted std::map causes infinite loop).
+  #
+  # This proves the mutex is necessary, not just defensive.
+  #
+  # Runs in a subprocess with a timeout so neither a crash nor a hang
+  # kills the test runner.
+  #
+  # The number of objects is calibrated to fill ~1 second of rapid-fire
+  # Counter.new calls, ensuring sufficient registry contention on any machine.
+
+  TIMEOUT_SECONDS = 30
+
+  SUBPROCESS_SCRIPT = <<~'RUBY'
+    $LOAD_PATH.unshift(ARGV[0])
+    require "ractor_test_unsafe_ext"
+
+    # Calibrate: how many Counter.new(0) fit in ~1 second?
+    count = 1_000
+    loop do
+      t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      count.times { Counter.new(0) }
+      break if Process.clock_gettime(Process::CLOCK_MONOTONIC) - t >= 1.0
+      count *= 2
+    end
+
+    # Launch concurrent Ractors with calibrated count
+    r1 = Ractor.new(count) { |n| n.times { Counter.new(0) }; :ok }
+    r2 = Ractor.new(count) { |n| n.times { Counter.new(0) }; :ok }
+    r1.take
+    r2.take
+  RUBY
+
+  def test_concurrent_access_without_mutex_fails
+    ext_dir = File.expand_path("ext_unsafe", __dir__)
+
+    pid = spawn(
+      RbConfig.ruby, "-e", SUBPROCESS_SCRIPT, ext_dir,
+      out: File::NULL, err: File::NULL
+    )
+
+    # Wait with timeout — hang is also a failure mode
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + TIMEOUT_SECONDS
+    status = nil
+
+    loop do
+      _, status = Process.wait2(pid, Process::WNOHANG)
+      break if status
+      if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        Process.kill("KILL", pid)
+        _, status = Process.wait2(pid)
+        break
+      end
+      sleep 0.1
+    end
+
+    if status.success?
+      skip "Race condition did not manifest in this run (non-deterministic)"
+    elsif status.termsig == 9 && Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline - 1
+      # We killed it after timeout — it was hanging (corrupted map)
+      pass # Hang confirms the corruption
+    else
+      # Crashed with a signal — segfault, abort, etc.
+      assert status.signaled?,
+        "Expected crash or hang without RICE_RACTOR_SAFE, got exit #{status.exitstatus}"
+    end
+  end
+end


### PR DESCRIPTION
Hi there,

I'd like to propose an opt-in mechanism for Ractor safety in Rice. I understand this touches a sensitive area — the docs explicitly state "Rice provides no mechanisms for dealing with thread safety" — so I want to explain the context that led here, and why I believe this is a minimal, safe change worth considering.

### Motivation

I'm the author of [MusaDSL](https://musadsl.yeste.studio), an algorithmic music composition framework for Ruby. I'm currently building a new module — a real-time counterpoint engine that generates multi-voice polyphony via constraint satisfaction. The engine uses [or-tools-ruby](https://github.com/ankane/or-tools-ruby) (Google's OR-Tools CP-SAT solver) for finding valid voice-leading solutions, and or-tools-ruby is built on Rice. For real-time performance, the solver needs to run inside a Ractor so it doesn't block the sequencer thread — which is how I encountered the InstanceRegistry thread-safety issue.

I got it working by marking the extension as Ractor-safe (`rb_ext_ractor_safe(true)`), but concurrent access from multiple Ractors caused segfaults.

After investigation, I traced the issue to a single point: **Rice's `InstanceRegistry`** — the `std::map` that tracks C++ object wrappers. It's the only Rice registry that performs writes at runtime (`add`, `lookup`, `remove`). The other registries (`TypeRegistry`, `NativeRegistry`, `HandlerRegistry`, `ModuleRegistry`) are all written once during `Init_*` and are read-only afterward.

### The change

When `RICE_RACTOR_SAFE` is defined at compile time, a `std::recursive_mutex` is added to `InstanceRegistry`, protecting all four mutable operations. Two files changed, 21 lines added:

- `rice/detail/InstanceRegistry.hpp` — conditional `#include <mutex>` + mutex member
- `rice/detail/InstanceRegistry.ipp` — `std::lock_guard` in `lookup`, `add`, `remove`, `clear`

Without the define, the generated code is **identical** to the current Rice — no mutex, no overhead, no behavior change. Existing projects are completely unaffected.

Consumers opt in via their `extconf.rb`:

```ruby
$CXXFLAGS << " -DRICE_RACTOR_SAFE"
```

### Tests

The PR includes two Minitest test suites in `test/ruby/` (matching the existing `Rake::TestTask` glob):

**Positive tests** (`test_ractor.rb`) — a minimal Rice extension compiled with `-DRICE_RACTOR_SAFE`:
- Single Ractor, sequential Ractors, concurrent Ractors
- Many objects in a Ractor (50 objects stressing the registry)
- Main thread + Ractor simultaneously
- Calibrated heavy concurrency: constructor duration calibrated to ~1s per object, 2 Ractors × 3 objects overlapping
- Calibrated fast concurrency: number of `Counter.new` calls calibrated to fill ~1s, 2 Ractors creating that many objects simultaneously

**Negative test** (`test_ractor_unsafe.rb`) — same extension compiled WITHOUT the define:
- Runs in a subprocess (so a crash doesn't kill the test runner)
- Concurrent Ractors with calibrated object count → hang or segfault confirmed
- 30s timeout — corruption of the unprotected `std::map` manifests as an infinite loop in the red-black tree, not always as a segfault

Both calibration strategies ensure the tests produce meaningful contention on any machine, fast or slow.

### Why not a mutex by default?

I considered making the mutex unconditional, but:
- It would change Rice's performance characteristics for all users
- The overhead is small but nonzero (mutex acquire/release on every object wrap/unwrap)
- Most Ruby C extensions don't use Ractors today

The opt-in approach lets Ractor-aware projects enable it explicitly while keeping the default behavior unchanged.

### Compatibility

Tested with Ruby 3.4.x (where Ractors are experimental). Ruby 4.x compatibility is pending validation — the Ractor API may change, but the mutex mechanism itself is pure C++ and should remain valid.

### Note on the `#include`

I'm aware of the project policy about not adding `#include` directives to arbitrary files. The `#include <mutex>` is inside `InstanceRegistry.hpp` itself (not in `rice.hpp`), and is conditional on `#ifdef RICE_RACTOR_SAFE`. I believe this is the least invasive placement, but I'm happy to move it if you prefer a different approach.

---

I realize this is a change in Rice's stance on thread safety, and I completely understand if you'd prefer to approach it differently. I'm open to any feedback — whether that's changes to the implementation, a different API surface, or even just keeping this in a fork until Ractors stabilize. The important thing for me was to identify the exact problem (InstanceRegistry is the only runtime-mutable registry) and demonstrate that a minimal fix works.

Thank you for maintaining Rice — it's a remarkable piece of engineering that makes the Ruby/C++ boundary feel natural.